### PR TITLE
chore: migrate MIME type validation script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "globals": "^15.14.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.0.0",
+        "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.19.0"
       },
@@ -525,6 +526,448 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -2401,6 +2844,48 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2981,6 +3466,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4820,6 +5318,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -5316,6 +5824,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
-    "test:mime-types": "npx tsx scripts/test-mime-types.ts",
+    "test:mime-types": "tsx scripts/test-mime-types.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepublishOnly": "npm run build"
@@ -50,6 +50,7 @@
     "globals": "^15.14.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.0.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
+    "test:mime-types": "npx tsx scripts/test-mime-types.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepublishOnly": "npm run build"

--- a/scripts/mime-type-validation-report.json
+++ b/scripts/mime-type-validation-report.json
@@ -1,0 +1,261 @@
+{
+  "totalTests": 36,
+  "passed": 36,
+  "failed": 0,
+  "skipped": 0,
+  "results": [
+    {
+      "extension": ".pdf",
+      "mimeType": "application/pdf",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 3151
+    },
+    {
+      "extension": ".xml",
+      "mimeType": "application/xml",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2314
+    },
+    {
+      "extension": ".txt",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1828
+    },
+    {
+      "extension": ".text",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1543
+    },
+    {
+      "extension": ".log",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1675
+    },
+    {
+      "extension": ".out",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1832
+    },
+    {
+      "extension": ".env",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1977
+    },
+    {
+      "extension": ".gitignore",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2286
+    },
+    {
+      "extension": ".gitattributes",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1556
+    },
+    {
+      "extension": ".dockerignore",
+      "mimeType": "text/plain",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1957
+    },
+    {
+      "extension": ".html",
+      "mimeType": "text/html",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2300
+    },
+    {
+      "extension": ".htm",
+      "mimeType": "text/html",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1865
+    },
+    {
+      "extension": ".md",
+      "mimeType": "text/markdown",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1423
+    },
+    {
+      "extension": ".markdown",
+      "mimeType": "text/markdown",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1591
+    },
+    {
+      "extension": ".mdown",
+      "mimeType": "text/markdown",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1866
+    },
+    {
+      "extension": ".mkd",
+      "mimeType": "text/markdown",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1847
+    },
+    {
+      "extension": ".c",
+      "mimeType": "text/x-c",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1882
+    },
+    {
+      "extension": ".h",
+      "mimeType": "text/x-c",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1975
+    },
+    {
+      "extension": ".java",
+      "mimeType": "text/x-java",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1595
+    },
+    {
+      "extension": ".kt",
+      "mimeType": "text/x-kotlin",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1679
+    },
+    {
+      "extension": ".kts",
+      "mimeType": "text/x-kotlin",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1707
+    },
+    {
+      "extension": ".go",
+      "mimeType": "text/x-go",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1917
+    },
+    {
+      "extension": ".py",
+      "mimeType": "text/x-python",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2150
+    },
+    {
+      "extension": ".pyw",
+      "mimeType": "text/x-python",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1692
+    },
+    {
+      "extension": ".pyx",
+      "mimeType": "text/x-python",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2172
+    },
+    {
+      "extension": ".pyi",
+      "mimeType": "text/x-python",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2077
+    },
+    {
+      "extension": ".pl",
+      "mimeType": "text/x-perl",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2494
+    },
+    {
+      "extension": ".pm",
+      "mimeType": "text/x-perl",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2270
+    },
+    {
+      "extension": ".t",
+      "mimeType": "text/x-perl",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1728
+    },
+    {
+      "extension": ".pod",
+      "mimeType": "text/x-perl",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1917
+    },
+    {
+      "extension": ".lua",
+      "mimeType": "text/x-lua",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2235
+    },
+    {
+      "extension": ".erl",
+      "mimeType": "text/x-erlang",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1946
+    },
+    {
+      "extension": ".hrl",
+      "mimeType": "text/x-erlang",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1697
+    },
+    {
+      "extension": ".tcl",
+      "mimeType": "text/x-tcl",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1428
+    },
+    {
+      "extension": ".bib",
+      "mimeType": "text/x-bibtex",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 2284
+    },
+    {
+      "extension": ".diff",
+      "mimeType": "text/x-diff",
+      "status": "pass",
+      "message": "Upload successful",
+      "duration": 1620
+    }
+  ],
+  "duration": 70174
+}

--- a/scripts/test-mime-types.ts
+++ b/scripts/test-mime-types.ts
@@ -354,7 +354,7 @@ async function main() {
 // Run if executed directly (ESM equivalent of require.main === module)
 const isMainModule = (() => {
   try {
-    const scriptPath = fileURLToPath(import.meta.url);
+    const scriptPath = realpathSync(fileURLToPath(import.meta.url));
     const argPath = process.argv[1] ? realpathSync(process.argv[1]) : '';
     return scriptPath === argPath;
   } catch {

--- a/scripts/test-mime-types.ts
+++ b/scripts/test-mime-types.ts
@@ -75,7 +75,10 @@ class MimeTypeValidator {
     try {
       console.log(`Creating test file search store...`);
       const store = await manager.createStore(displayName);
-      this.testStoreName = store.name!;
+      if (!store.name) {
+        throw new Error('Store created but no name returned from API');
+      }
+      this.testStoreName = store.name;
       console.log(`✓ Test store created: ${this.testStoreName}\n`);
       return this.testStoreName;
     } catch (error: unknown) {
@@ -132,11 +135,12 @@ class MimeTypeValidator {
     console.log(`\n${'='.repeat(60)}`);
     console.log('MIME Type Validation Suite');
     console.log(`${'='.repeat(60)}\n`);
-    console.log(`Testing ${extensions.length} MIME types against ${this.testStoreName}\n`);
 
     try {
       // Create test store
       await this.createTestStore();
+
+      console.log(`Testing ${extensions.length} MIME types against ${this.testStoreName}\n`);
 
       // Ensure sample directory exists
       if (!fs.existsSync(this.sampleDir)) {
@@ -303,7 +307,7 @@ class MimeTypeValidator {
   async saveReportToFile(filename: string, report?: TestReport): Promise<void> {
     const reportToSave = report ?? this.generateReport(Date.now() - this.startTime);
     const reportJson = JSON.stringify(reportToSave, null, 2);
-    fs.writeFileSync(filename, reportJson);
+    await fs.promises.writeFile(filename, reportJson);
     console.log(`Report saved to: ${filename}`);
   }
 }

--- a/scripts/test-mime-types.ts
+++ b/scripts/test-mime-types.ts
@@ -58,10 +58,10 @@ class MimeTypeValidator {
   private sampleDir: string;
   private startTime: number = 0;
 
-  constructor(apiKey: string, testStoreName: string) {
+  constructor(apiKey: string) {
     this.client = new GoogleGenAI({ apiKey });
     this.uploader = new FileUploader(this.client);
-    this.testStoreName = testStoreName;
+    this.testStoreName = '';
     this.sampleDir = path.join(__dirname, 'sample-files');
   }
 
@@ -91,7 +91,7 @@ class MimeTypeValidator {
       try {
         const storesResponse = await manager.listStores();
         const stores = storesResponse?.fileSearchStores ?? [];
-        const existingStore = stores.find((s: any) => s.displayName === displayName);
+        const existingStore = stores.find((s) => s.displayName === displayName);
 
         if (existingStore?.name) {
           this.testStoreName = existingStore.name;
@@ -225,9 +225,6 @@ class MimeTypeValidator {
     if (ext === '.pdf') {
       // Minimal valid PDF
       content = '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj xref 0 4 trailer<</Size 4/Root 1 0 R>>startxref 0 %%EOF';
-    } else if (ext === '.zip') {
-      // Minimal valid ZIP (empty archive)
-      content = Buffer.from([0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
     } else {
       // For text formats, create sample content
       content = `Sample file for ${ext} MIME type testing.\n`;
@@ -268,10 +265,11 @@ class MimeTypeValidator {
     console.log(`${'='.repeat(60)}\n`);
 
     // Summary
+    const pct = (n: number) => report.totalTests > 0 ? ((n / report.totalTests) * 100).toFixed(1) : '0.0';
     console.log('Summary:');
     console.log(`  Total Tests:  ${report.totalTests}`);
-    console.log(`  Passed:       ${report.passed} (${((report.passed / report.totalTests) * 100).toFixed(1)}%)`);
-    console.log(`  Failed:       ${report.failed} (${((report.failed / report.totalTests) * 100).toFixed(1)}%)`);
+    console.log(`  Passed:       ${report.passed} (${pct(report.passed)}%)`);
+    console.log(`  Failed:       ${report.failed} (${pct(report.failed)}%)`);
     if (report.skipped > 0) {
       console.log(`  Skipped:      ${report.skipped}`);
     }
@@ -328,7 +326,7 @@ async function main() {
 
   try {
     // Create validator with a placeholder name (will be set when store is created)
-    const validator = new MimeTypeValidator(apiKey, 'temp');
+    const validator = new MimeTypeValidator(apiKey);
     const report = await validator.validateAllMimeTypes();
 
     // Save report to file
@@ -349,7 +347,7 @@ async function main() {
 
 // Run if executed directly (ESM equivalent of require.main === module)
 const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-                     process.argv[1]?.endsWith('test-mime-types.ts');
+                     process.argv[1]?.endsWith('/scripts/test-mime-types.ts');
 if (isMainModule) {
   main().catch((error) => {
     console.error('Unhandled error:', error);

--- a/scripts/test-mime-types.ts
+++ b/scripts/test-mime-types.ts
@@ -1,0 +1,360 @@
+#!/usr/bin/env npx tsx
+/**
+ * Manual MIME Type Validation Suite
+ *
+ * This script validates all MIME type mappings against the real Gemini File Search API.
+ * It creates a temporary test store, uploads sample files for each supported extension,
+ * and then cleans up by deleting the test store.
+ *
+ * Usage:
+ *   npm run test:mime-types
+ *   npx tsx scripts/test-mime-types.ts
+ *
+ * Environment:
+ *   GEMINI_API_KEY - Required Gemini API key
+ *
+ * Output:
+ *   - Console report with summary of passed/failed MIME types
+ *   - JSON report saved to scripts/mime-type-validation-report.json
+ */
+
+import { GoogleGenAI } from '@google/genai';
+import {
+  FileUploader,
+  FileSearchManager,
+  getSupportedExtensions,
+  EXTENSION_TO_MIME,
+} from '../src/index.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// ESM equivalents for __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface TestResult {
+  extension: string;
+  mimeType: string;
+  status: 'pass' | 'fail' | 'skip';
+  message: string;
+  duration?: number;
+}
+
+interface TestReport {
+  totalTests: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  results: TestResult[];
+  duration: number;
+}
+
+class MimeTypeValidator {
+  private client: GoogleGenAI;
+  private uploader: FileUploader;
+  private testStoreName: string;
+  private results: TestResult[] = [];
+  private sampleDir: string;
+  private startTime: number = 0;
+
+  constructor(apiKey: string, testStoreName: string) {
+    this.client = new GoogleGenAI({ apiKey });
+    this.uploader = new FileUploader(this.client);
+    this.testStoreName = testStoreName;
+    this.sampleDir = path.join(__dirname, 'sample-files');
+  }
+
+  /**
+   * Creates a test file search store
+   */
+  private async createTestStore(): Promise<string> {
+    const displayName = 'mime-type-test-store';
+    const manager = new FileSearchManager(this.client);
+
+    try {
+      console.log(`Creating test file search store...`);
+      const store = await manager.createStore(displayName);
+      this.testStoreName = store.name!;
+      console.log(`✓ Test store created: ${this.testStoreName}\n`);
+      return this.testStoreName;
+    } catch (error: unknown) {
+      const errorMessage = (error as Error)?.message ?? String(error);
+      const isAlreadyExists = errorMessage.includes('already exists') || errorMessage.includes('ALREADY_EXISTS');
+
+      if (!isAlreadyExists) {
+        throw error;
+      }
+
+      // Store already exists - find it by listing stores and matching displayName
+      console.log(`Store already exists. Looking up existing store...`);
+      try {
+        const storesResponse = await manager.listStores();
+        const stores = storesResponse?.fileSearchStores ?? [];
+        const existingStore = stores.find((s: any) => s.displayName === displayName);
+
+        if (existingStore?.name) {
+          this.testStoreName = existingStore.name;
+          console.log(`✓ Found existing store: ${this.testStoreName}\n`);
+          return this.testStoreName;
+        }
+
+        // Store exists but couldn't find it - this shouldn't happen
+        throw new Error(`Store '${displayName}' exists but could not be found in store list`);
+      } catch (listError: unknown) {
+        const listErrorMessage = (listError as Error)?.message ?? String(listError);
+        throw new Error(`Failed to retrieve existing store: ${listErrorMessage}`);
+      }
+    }
+  }
+
+  /**
+   * Deletes the test file search store
+   */
+  private async deleteTestStore(): Promise<void> {
+    try {
+      console.log(`\nCleaning up test store: ${this.testStoreName}...`);
+      const manager = new FileSearchManager(this.client);
+      await manager.deleteStore(this.testStoreName, true); // force delete
+      console.log(`✓ Test store deleted successfully`);
+    } catch (error: any) {
+      console.error(`Warning: Failed to delete test store: ${error.message}`);
+    }
+  }
+
+  /**
+   * Validates all MIME types by testing each supported extension
+   */
+  async validateAllMimeTypes(): Promise<TestReport> {
+    this.startTime = Date.now();
+    const extensions = getSupportedExtensions();
+
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('MIME Type Validation Suite');
+    console.log(`${'='.repeat(60)}\n`);
+    console.log(`Testing ${extensions.length} MIME types against ${this.testStoreName}\n`);
+
+    try {
+      // Create test store
+      await this.createTestStore();
+
+      // Ensure sample directory exists
+      if (!fs.existsSync(this.sampleDir)) {
+        fs.mkdirSync(this.sampleDir, { recursive: true });
+      }
+
+      // Test each extension
+      let progressCount = 0;
+      for (const ext of extensions) {
+        progressCount++;
+        process.stdout.write(`\rProgress: ${progressCount}/${extensions.length} (${Math.round((progressCount / extensions.length) * 100)}%)`);
+        await this.testExtension(ext);
+      }
+
+      console.log('\n'); // New line after progress
+    } finally {
+      // Clean up sample directory
+      if (fs.existsSync(this.sampleDir)) {
+        fs.rmSync(this.sampleDir, { recursive: true, force: true });
+      }
+
+      // Delete test store
+      await this.deleteTestStore();
+    }
+
+    const duration = Date.now() - this.startTime;
+    const report = this.generateReport(duration);
+    this.printReport(report);
+
+    return report;
+  }
+
+  /**
+   * Tests a single extension by creating a sample file and uploading it
+   */
+  private async testExtension(ext: string): Promise<void> {
+    const mimeType = EXTENSION_TO_MIME[ext];
+    const testFilePath = this.createSampleFile(ext);
+    const testStart = Date.now();
+
+    try {
+      await this.uploader.uploadFile(testFilePath, this.testStoreName);
+
+      this.results.push({
+        extension: ext,
+        mimeType,
+        status: 'pass',
+        message: 'Upload successful',
+        duration: Date.now() - testStart,
+      });
+    } catch (error: any) {
+      // Sanitize error message to use relative paths
+      const rawMessage = error.message || String(error);
+      const sanitizedMessage = rawMessage.replace(this.sampleDir, './sample-files');
+
+      this.results.push({
+        extension: ext,
+        mimeType,
+        status: 'fail',
+        message: sanitizedMessage,
+        duration: Date.now() - testStart,
+      });
+    } finally {
+      // Clean up test file
+      try {
+        if (fs.existsSync(testFilePath)) {
+          fs.unlinkSync(testFilePath);
+        }
+      } catch (cleanupError) {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  /**
+   * Creates a sample file with the given extension
+   */
+  private createSampleFile(ext: string): string {
+    const fileName = `test${ext}`;
+    const filePath = path.join(this.sampleDir, fileName);
+
+    // Create appropriate sample content based on file type
+    let content: string | Buffer;
+
+    // For binary formats, create minimal valid content
+    if (ext === '.pdf') {
+      // Minimal valid PDF
+      content = '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj xref 0 4 trailer<</Size 4/Root 1 0 R>>startxref 0 %%EOF';
+    } else if (ext === '.zip') {
+      // Minimal valid ZIP (empty archive)
+      content = Buffer.from([0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    } else {
+      // For text formats, create sample content
+      content = `Sample file for ${ext} MIME type testing.\n`;
+      content += `MIME Type: ${EXTENSION_TO_MIME[ext]}\n`;
+      content += `Generated at: ${new Date().toISOString()}\n`;
+      content += `File extension: ${ext}\n`;
+      content += '\nThis is test content for validating MIME type support in the Gemini File Search API.\n';
+    }
+
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  /**
+   * Generates a test report from the results
+   */
+  private generateReport(duration: number): TestReport {
+    const passed = this.results.filter(r => r.status === 'pass').length;
+    const failed = this.results.filter(r => r.status === 'fail').length;
+    const skipped = this.results.filter(r => r.status === 'skip').length;
+
+    return {
+      totalTests: this.results.length,
+      passed,
+      failed,
+      skipped,
+      results: this.results,
+      duration,
+    };
+  }
+
+  /**
+   * Prints the test report to console
+   */
+  private printReport(report: TestReport): void {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('MIME Type Validation Report');
+    console.log(`${'='.repeat(60)}\n`);
+
+    // Summary
+    console.log('Summary:');
+    console.log(`  Total Tests:  ${report.totalTests}`);
+    console.log(`  Passed:       ${report.passed} (${((report.passed / report.totalTests) * 100).toFixed(1)}%)`);
+    console.log(`  Failed:       ${report.failed} (${((report.failed / report.totalTests) * 100).toFixed(1)}%)`);
+    if (report.skipped > 0) {
+      console.log(`  Skipped:      ${report.skipped}`);
+    }
+    console.log(`  Duration:     ${(report.duration / 1000).toFixed(2)}s`);
+    console.log();
+
+    // Failed tests
+    if (report.failed > 0) {
+      console.log('Failed Extensions:');
+      const failedResults = report.results.filter(r => r.status === 'fail');
+      for (const result of failedResults) {
+        console.log(`  ✗ ${result.extension.padEnd(12)} (${result.mimeType})`);
+        console.log(`    Error: ${result.message}`);
+      }
+      console.log();
+    }
+
+    // Success message
+    if (report.failed === 0) {
+      console.log('✓ All MIME types validated successfully!');
+    } else {
+      console.log(`⚠ ${report.failed} MIME type(s) failed validation`);
+    }
+
+    console.log(`\n${'='.repeat(60)}\n`);
+  }
+
+  /**
+   * Saves the report to a JSON file
+   */
+  async saveReportToFile(filename: string, report?: TestReport): Promise<void> {
+    const reportToSave = report ?? this.generateReport(Date.now() - this.startTime);
+    const reportJson = JSON.stringify(reportToSave, null, 2);
+    fs.writeFileSync(filename, reportJson);
+    console.log(`Report saved to: ${filename}`);
+  }
+}
+
+/**
+ * CLI entry point
+ */
+async function main() {
+  // Get API key
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GEMINI_DEEP_RESEARCH_API_KEY;
+  if (!apiKey) {
+    console.error('Error: API key not found.');
+    console.error('Please set GEMINI_API_KEY or GEMINI_DEEP_RESEARCH_API_KEY environment variable.');
+    process.exit(1);
+  }
+
+  console.log('Starting MIME Type Validation...');
+  console.log('Note: This will create a temporary test store, run validation, and clean up.\n');
+  console.log('This may take several minutes depending on the number of MIME types.\n');
+
+  try {
+    // Create validator with a placeholder name (will be set when store is created)
+    const validator = new MimeTypeValidator(apiKey, 'temp');
+    const report = await validator.validateAllMimeTypes();
+
+    // Save report to file
+    const reportPath = path.join(__dirname, 'mime-type-validation-report.json');
+    await validator.saveReportToFile(reportPath, report);
+
+    // Exit with error code if there were failures
+    if (report.failed > 0) {
+      console.log(`\n⚠ ${report.failed} MIME type(s) failed - see report for details`);
+      process.exit(1);
+    }
+  } catch (error: any) {
+    console.error('\nFatal error during validation:');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly (ESM equivalent of require.main === module)
+const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
+                     process.argv[1]?.endsWith('test-mime-types.ts');
+if (isMainModule) {
+  main().catch((error) => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+export { MimeTypeValidator };

--- a/scripts/test-mime-types.ts
+++ b/scripts/test-mime-types.ts
@@ -28,6 +28,7 @@ import {
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { realpathSync } from 'fs';
 
 // ESM equivalents for __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -120,8 +121,9 @@ class MimeTypeValidator {
       const manager = new FileSearchManager(this.client);
       await manager.deleteStore(this.testStoreName, true); // force delete
       console.log(`✓ Test store deleted successfully`);
-    } catch (error: any) {
-      console.error(`Warning: Failed to delete test store: ${error.message}`);
+    } catch (error: unknown) {
+      const errorMessage = (error as Error)?.message ?? String(error);
+      console.error(`Warning: Failed to delete test store: ${errorMessage}`);
     }
   }
 
@@ -191,9 +193,9 @@ class MimeTypeValidator {
         message: 'Upload successful',
         duration: Date.now() - testStart,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Sanitize error message to use relative paths
-      const rawMessage = error.message || String(error);
+      const rawMessage = (error as Error)?.message ?? String(error);
       const sanitizedMessage = rawMessage.replace(this.sampleDir, './sample-files');
 
       this.results.push({
@@ -342,7 +344,7 @@ async function main() {
       console.log(`\n⚠ ${report.failed} MIME type(s) failed - see report for details`);
       process.exit(1);
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('\nFatal error during validation:');
     console.error(error);
     process.exit(1);
@@ -350,8 +352,15 @@ async function main() {
 }
 
 // Run if executed directly (ESM equivalent of require.main === module)
-const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-                     process.argv[1]?.endsWith('/scripts/test-mime-types.ts');
+const isMainModule = (() => {
+  try {
+    const scriptPath = fileURLToPath(import.meta.url);
+    const argPath = process.argv[1] ? realpathSync(process.argv[1]) : '';
+    return scriptPath === argPath;
+  } catch {
+    return false;
+  }
+})();
 if (isMainModule) {
   main().catch((error) => {
     console.error('Unhandled error:', error);


### PR DESCRIPTION
## Summary
- Migrate `test-mime-types.ts` script from gemini-cli-deep-research repo
- Include `mime-type-validation-report.json` with latest validation results
- Add `npm run test:mime-types` script to package.json
- Update script for ESM compatibility using `tsx`

## Test plan
- [x] Verify script runs successfully with `npm run test:mime-types`
- [x] Confirm all 36 MIME types pass validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end MIME type validation workflow for file uploads with progress reporting and a saved JSON summary report.

* **Tests**
  * Comprehensive per-extension validation run included; all tested types passed in the bundled report.

* **Chores**
  * Added a convenience script to run the validation and a development dependency to support its execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->