### PR TITLE
fix: reduce page size to comply with API limit

### DIFF
--- a/src/file-search/FileSearchManager.test.ts
+++ b/src/file-search/FileSearchManager.test.ts
@@ -121,7 +121,7 @@ describe('FileSearchManager', () => {
 
       expect(mockClient.fileSearchStores.documents.list).toHaveBeenCalledWith({
         parent: 'stores/store1',
-        config: { pageSize: 100 },
+        config: { pageSize: 20 },
       });
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe('documents/1');

--- a/src/file-search/FileSearchManager.ts
+++ b/src/file-search/FileSearchManager.ts
@@ -101,7 +101,7 @@ export class FileSearchManager {
     const allDocuments: FileSearchDocument[] = [];
     const pager = await this.client.fileSearchStores.documents.list({
       parent: storeName,
-      config: { pageSize: 100 },
+      config: { pageSize: 20 },
     });
 
     // Iterate through all pages


### PR DESCRIPTION
## Summary
- Reduces `pageSize` from 100 to 20 when listing documents in file search stores
- The Gemini API requires `page_size` to be between 1 and 20

## Problem
API returns 400 error:
```
page_size must be between 1 and 20
```

## Test plan
- [x] Updated test to expect pageSize of 20
- Existing pagination logic handles multiple pages correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated document pagination batch size to retrieve documents in smaller increments per request.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->