### PR TITLE
ci: add strict lint and typecheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,28 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint (strict)
+        run: npm run lint -- --max-warnings 0
+
+      - name: Run TypeScript type check
+        run: npm run typecheck
+
   test:
     runs-on: ubuntu-latest
 
@@ -26,9 +48,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint
 
       - name: Run tests with coverage
         run: npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:mime-types": "tsx scripts/test-mime-types.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
+    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/src/file-search/FileUploader.ts
+++ b/src/file-search/FileUploader.ts
@@ -1,4 +1,5 @@
-import { GoogleGenAI, UploadToFileSearchStoreConfig } from '@google/genai';
+import { GoogleGenAI } from '@google/genai';
+import type { ChunkingConfig, UploadToFileSearchStoreConfig } from '@google/genai';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -39,7 +40,7 @@ export interface Logger {
  */
 export interface UploadConfig {
   /** Chunking configuration for the upload */
-  chunkingConfig?: unknown;
+  chunkingConfig?: ChunkingConfig;
   /** Relative path to use for the file (defaults to filename) */
   relativePath?: string;
   /** Progress callback for tracking upload status */
@@ -53,7 +54,7 @@ export interface UploadConfig {
  */
 export interface BatchUploadConfig {
   /** Chunking configuration for uploads */
-  chunkingConfig?: unknown;
+  chunkingConfig?: ChunkingConfig;
   /** Progress callback for tracking upload status */
   onProgress?: ProgressCallback;
   /** Parallel upload configuration */
@@ -171,20 +172,22 @@ export class FileUploader {
         fileData = content.data;
       }
 
+      const uploadConfig = {
+        displayName: content.displayName,
+        mimeType: content.mimeType,
+        chunkingConfig: config?.chunkingConfig,
+        customMetadata: [
+          { key: 'path', stringValue: content.relativePath },
+          { key: 'hash', stringValue: content.hash },
+          { key: 'last_modified', stringValue: content.lastModified },
+          ...(content.customMetadata || []),
+        ],
+      } satisfies UploadToFileSearchStoreConfig;
+
       const op = await this.client.fileSearchStores.uploadToFileSearchStore({
         fileSearchStoreName: storeName,
         file: fileData,
-        config: {
-          displayName: content.displayName,
-          mimeType: content.mimeType,
-          chunkingConfig: config?.chunkingConfig,
-          customMetadata: [
-            { key: 'path', stringValue: content.relativePath },
-            { key: 'hash', stringValue: content.hash },
-            { key: 'last_modified', stringValue: content.lastModified },
-            ...(content.customMetadata || []),
-          ],
-        } as UploadToFileSearchStoreConfig,
+        config: uploadConfig,
       });
 
       // Call completion callback before emitting progress event


### PR DESCRIPTION
## Summary
- Split lint into a separate parallel job for faster CI feedback
- Run ESLint with `--max-warnings 0` to enforce zero tolerance on warnings
- Add TypeScript type checking (`tsc --noEmit`) to catch type errors early
- Fix existing lint warning by using proper `UploadToFileSearchStoreConfig` type

## Test plan
- [ ] Verify lint job runs in parallel with test jobs
- [ ] Verify CI fails if any ESLint warnings are introduced
- [ ] Verify CI fails if TypeScript type errors are introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated: added a strict lint + type-check job and removed linting from the main test job.
  * Added a TypeScript type-check script to project scripts.

* **Refactor**
  * Improved typing for file upload configuration, tightening the public chunking configuration type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->