### PR TITLE
feat: add MIME type support registry

### DIFF
--- a/.github/workflows/probe-gemini-support.yml
+++ b/.github/workflows/probe-gemini-support.yml
@@ -1,0 +1,59 @@
+name: Probe Gemini MIME Type Support
+
+on:
+  schedule:
+    # Run weekly on Sundays at 04:00 UTC
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      models:
+        description: 'Comma-separated model names to probe'
+        required: false
+        default: 'gemini-3.0-flash-preview'
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run MIME type probe
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          MODELS="${{ github.event.inputs.models || 'gemini-3.0-flash-preview' }}"
+          npx tsx scripts/probe-mime-types.ts --model "$MODELS"
+
+      - name: Check for matrix changes
+        id: changes
+        run: |
+          git diff --quiet src/generated/gemini-support-matrix.json && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: update Gemini MIME type support matrix'
+          title: 'chore: update Gemini MIME type support matrix'
+          body: |
+            ## Summary
+            - Automated weekly probe of Gemini API MIME type support
+            - Updates `src/generated/gemini-support-matrix.json` with latest probe results
+
+            ## Changes
+            Run `git diff` on the matrix JSON to see which MIME types changed support status.
+          branch: chore/update-support-matrix
+          delete-branch: true
+          labels: automated,dependencies

--- a/.github/workflows/probe-gemini-support.yml
+++ b/.github/workflows/probe-gemini-support.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: 'gemini-3.0-flash-preview'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   probe:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_Store
 coverage/
 .env
+
+# Generated probe/validation reports
+scripts/*-report.json

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
     "test:mime-types": "tsx scripts/test-mime-types.ts",
+    "test:probe-mime-types": "tsx scripts/probe-mime-types.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "typecheck": "tsc --noEmit",

--- a/scripts/probe-mime-types.ts
+++ b/scripts/probe-mime-types.ts
@@ -928,7 +928,7 @@ function parseArgs(): {
       }
       i++;
     } else if (args[i] === '--category' && args[i + 1]) {
-      options.categories = args[i + 1].split(',');
+      options.categories = args[i + 1].split(',').map(c => c.trim());
       i++;
     } else if (args[i] === '--model' && args[i + 1]) {
       options.models = args[i + 1].split(',').map(m => m.trim());

--- a/scripts/probe-mime-types.ts
+++ b/scripts/probe-mime-types.ts
@@ -1,0 +1,823 @@
+#!/usr/bin/env npx tsx
+/**
+ * MIME Type Probe Script
+ *
+ * Probes the Gemini API to discover which MIME types are actually supported
+ * for two upload methods:
+ *   1. Inline base64 (via generateContent with inlineData)
+ *   2. File API upload (via client.files.upload)
+ *
+ * The Gemini documentation is often stale, so this script manually verifies
+ * what actually works by attempting real API calls with minimal sample files.
+ *
+ * Usage:
+ *   npm run test:probe-mime-types
+ *   npx tsx scripts/probe-mime-types.ts
+ *   npx tsx scripts/probe-mime-types.ts --method inline
+ *   npx tsx scripts/probe-mime-types.ts --method file-api
+ *   npx tsx scripts/probe-mime-types.ts --category image
+ *
+ * Environment:
+ *   GEMINI_API_KEY - Required Gemini API key
+ *
+ * Output:
+ *   - Console report with summary
+ *   - JSON report saved to scripts/probe-mime-types-report.json
+ */
+
+import { GoogleGenAI } from '@google/genai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+import { realpathSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MimeTypeEntry {
+  mimeType: string;
+  extension: string;
+  category: string;
+  /** Description of the content type */
+  description: string;
+  /** Whether this requires binary content (vs text) */
+  binary: boolean;
+}
+
+interface ProbeResult {
+  mimeType: string;
+  extension: string;
+  category: string;
+  description: string;
+  inline: TestOutcome;
+  fileApi: TestOutcome;
+}
+
+interface TestOutcome {
+  status: 'pass' | 'fail' | 'skip';
+  message: string;
+  durationMs?: number;
+}
+
+interface ProbeReport {
+  timestamp: string;
+  model: string;
+  totalMimeTypes: number;
+  methods: {
+    inline: { passed: number; failed: number; skipped: number };
+    fileApi: { passed: number; failed: number; skipped: number };
+  };
+  results: ProbeResult[];
+  durationMs: number;
+}
+
+// ============================================================================
+// Comprehensive MIME type catalog
+// ============================================================================
+
+const MIME_TYPE_CATALOG: MimeTypeEntry[] = [
+  // --- Images ---
+  { mimeType: 'image/png', extension: '.png', category: 'image', description: 'PNG image', binary: true },
+  { mimeType: 'image/jpeg', extension: '.jpg', category: 'image', description: 'JPEG image', binary: true },
+  { mimeType: 'image/gif', extension: '.gif', category: 'image', description: 'GIF image', binary: true },
+  { mimeType: 'image/webp', extension: '.webp', category: 'image', description: 'WebP image', binary: true },
+  { mimeType: 'image/bmp', extension: '.bmp', category: 'image', description: 'BMP image', binary: true },
+  { mimeType: 'image/tiff', extension: '.tiff', category: 'image', description: 'TIFF image', binary: true },
+  { mimeType: 'image/svg+xml', extension: '.svg', category: 'image', description: 'SVG image', binary: false },
+  { mimeType: 'image/x-icon', extension: '.ico', category: 'image', description: 'ICO icon', binary: true },
+  { mimeType: 'image/heic', extension: '.heic', category: 'image', description: 'HEIC image', binary: true },
+  { mimeType: 'image/heif', extension: '.heif', category: 'image', description: 'HEIF image', binary: true },
+  { mimeType: 'image/avif', extension: '.avif', category: 'image', description: 'AVIF image', binary: true },
+
+  // --- Audio ---
+  { mimeType: 'audio/mpeg', extension: '.mp3', category: 'audio', description: 'MP3 audio', binary: true },
+  { mimeType: 'audio/wav', extension: '.wav', category: 'audio', description: 'WAV audio', binary: true },
+  { mimeType: 'audio/flac', extension: '.flac', category: 'audio', description: 'FLAC audio', binary: true },
+  { mimeType: 'audio/aac', extension: '.aac', category: 'audio', description: 'AAC audio', binary: true },
+  { mimeType: 'audio/ogg', extension: '.ogg', category: 'audio', description: 'OGG audio', binary: true },
+  { mimeType: 'audio/mp4', extension: '.m4a', category: 'audio', description: 'M4A audio', binary: true },
+  { mimeType: 'audio/webm', extension: '.weba', category: 'audio', description: 'WebM audio', binary: true },
+  { mimeType: 'audio/x-aiff', extension: '.aiff', category: 'audio', description: 'AIFF audio', binary: true },
+  { mimeType: 'audio/opus', extension: '.opus', category: 'audio', description: 'Opus audio', binary: true },
+  { mimeType: 'audio/amr', extension: '.amr', category: 'audio', description: 'AMR audio', binary: true },
+  { mimeType: 'audio/midi', extension: '.mid', category: 'audio', description: 'MIDI audio', binary: true },
+
+  // --- Video ---
+  { mimeType: 'video/mp4', extension: '.mp4', category: 'video', description: 'MP4 video', binary: true },
+  { mimeType: 'video/webm', extension: '.webm', category: 'video', description: 'WebM video', binary: true },
+  { mimeType: 'video/quicktime', extension: '.mov', category: 'video', description: 'QuickTime video', binary: true },
+  { mimeType: 'video/x-msvideo', extension: '.avi', category: 'video', description: 'AVI video', binary: true },
+  { mimeType: 'video/mpeg', extension: '.mpeg', category: 'video', description: 'MPEG video', binary: true },
+  { mimeType: 'video/x-matroska', extension: '.mkv', category: 'video', description: 'MKV video', binary: true },
+  { mimeType: 'video/x-flv', extension: '.flv', category: 'video', description: 'FLV video', binary: true },
+  { mimeType: 'video/3gpp', extension: '.3gp', category: 'video', description: '3GP video', binary: true },
+  { mimeType: 'video/3gpp2', extension: '.3g2', category: 'video', description: '3GP2 video', binary: true },
+  { mimeType: 'video/x-ms-wmv', extension: '.wmv', category: 'video', description: 'WMV video', binary: true },
+
+  // --- Documents ---
+  { mimeType: 'application/pdf', extension: '.pdf', category: 'document', description: 'PDF document', binary: true },
+  { mimeType: 'application/msword', extension: '.doc', category: 'document', description: 'Word document (legacy)', binary: true },
+  { mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', extension: '.docx', category: 'document', description: 'Word document (OOXML)', binary: true },
+  { mimeType: 'application/vnd.ms-excel', extension: '.xls', category: 'document', description: 'Excel spreadsheet (legacy)', binary: true },
+  { mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', extension: '.xlsx', category: 'document', description: 'Excel spreadsheet (OOXML)', binary: true },
+  { mimeType: 'application/vnd.ms-powerpoint', extension: '.ppt', category: 'document', description: 'PowerPoint (legacy)', binary: true },
+  { mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', extension: '.pptx', category: 'document', description: 'PowerPoint (OOXML)', binary: true },
+  { mimeType: 'application/rtf', extension: '.rtf', category: 'document', description: 'Rich Text Format', binary: false },
+  { mimeType: 'application/epub+zip', extension: '.epub', category: 'document', description: 'EPUB ebook', binary: true },
+
+  // --- Text / Code ---
+  { mimeType: 'text/plain', extension: '.txt', category: 'text', description: 'Plain text', binary: false },
+  { mimeType: 'text/html', extension: '.html', category: 'text', description: 'HTML', binary: false },
+  { mimeType: 'text/css', extension: '.css', category: 'text', description: 'CSS stylesheet', binary: false },
+  { mimeType: 'text/csv', extension: '.csv', category: 'text', description: 'CSV data', binary: false },
+  { mimeType: 'text/markdown', extension: '.md', category: 'text', description: 'Markdown', binary: false },
+  { mimeType: 'text/xml', extension: '.xml', category: 'text', description: 'XML', binary: false },
+  { mimeType: 'text/x-python', extension: '.py', category: 'text', description: 'Python source', binary: false },
+  { mimeType: 'text/javascript', extension: '.js', category: 'text', description: 'JavaScript source', binary: false },
+  { mimeType: 'text/x-typescript', extension: '.ts', category: 'text', description: 'TypeScript source', binary: false },
+  { mimeType: 'text/x-c', extension: '.c', category: 'text', description: 'C source', binary: false },
+  { mimeType: 'text/x-c++src', extension: '.cpp', category: 'text', description: 'C++ source', binary: false },
+  { mimeType: 'text/x-java', extension: '.java', category: 'text', description: 'Java source', binary: false },
+  { mimeType: 'text/x-go', extension: '.go', category: 'text', description: 'Go source', binary: false },
+  { mimeType: 'text/x-rust', extension: '.rs', category: 'text', description: 'Rust source', binary: false },
+  { mimeType: 'text/x-ruby', extension: '.rb', category: 'text', description: 'Ruby source', binary: false },
+  { mimeType: 'text/x-php', extension: '.php', category: 'text', description: 'PHP source', binary: false },
+  { mimeType: 'text/x-swift', extension: '.swift', category: 'text', description: 'Swift source', binary: false },
+  { mimeType: 'text/x-kotlin', extension: '.kt', category: 'text', description: 'Kotlin source', binary: false },
+  { mimeType: 'text/x-scala', extension: '.scala', category: 'text', description: 'Scala source', binary: false },
+  { mimeType: 'text/x-perl', extension: '.pl', category: 'text', description: 'Perl source', binary: false },
+  { mimeType: 'text/x-lua', extension: '.lua', category: 'text', description: 'Lua source', binary: false },
+  { mimeType: 'text/x-erlang', extension: '.erl', category: 'text', description: 'Erlang source', binary: false },
+  { mimeType: 'text/x-haskell', extension: '.hs', category: 'text', description: 'Haskell source', binary: false },
+  { mimeType: 'text/x-clojure', extension: '.clj', category: 'text', description: 'Clojure source', binary: false },
+  { mimeType: 'text/x-elixir', extension: '.ex', category: 'text', description: 'Elixir source', binary: false },
+  { mimeType: 'text/x-shellscript', extension: '.sh', category: 'text', description: 'Shell script', binary: false },
+  { mimeType: 'text/x-sql', extension: '.sql', category: 'text', description: 'SQL', binary: false },
+  { mimeType: 'text/x-diff', extension: '.diff', category: 'text', description: 'Diff/patch', binary: false },
+  { mimeType: 'text/x-yaml', extension: '.yaml', category: 'text', description: 'YAML', binary: false },
+  { mimeType: 'text/x-toml', extension: '.toml', category: 'text', description: 'TOML', binary: false },
+
+  // --- Structured data ---
+  { mimeType: 'application/json', extension: '.json', category: 'data', description: 'JSON', binary: false },
+  { mimeType: 'application/xml', extension: '.xmldata', category: 'data', description: 'XML data', binary: false },
+  { mimeType: 'application/x-yaml', extension: '.yamldata', category: 'data', description: 'YAML data', binary: false },
+  { mimeType: 'application/graphql', extension: '.graphql', category: 'data', description: 'GraphQL', binary: false },
+  { mimeType: 'application/ld+json', extension: '.jsonld', category: 'data', description: 'JSON-LD', binary: false },
+
+  // --- Archives (likely unsupported, but worth probing) ---
+  { mimeType: 'application/zip', extension: '.zip', category: 'archive', description: 'ZIP archive', binary: true },
+  { mimeType: 'application/gzip', extension: '.gz', category: 'archive', description: 'GZIP archive', binary: true },
+  { mimeType: 'application/x-tar', extension: '.tar', category: 'archive', description: 'TAR archive', binary: true },
+
+  // --- Fonts ---
+  { mimeType: 'font/woff', extension: '.woff', category: 'font', description: 'WOFF font', binary: true },
+  { mimeType: 'font/woff2', extension: '.woff2', category: 'font', description: 'WOFF2 font', binary: true },
+  { mimeType: 'font/ttf', extension: '.ttf', category: 'font', description: 'TrueType font', binary: true },
+  { mimeType: 'font/otf', extension: '.otf', category: 'font', description: 'OpenType font', binary: true },
+
+  // --- Other application types ---
+  { mimeType: 'application/javascript', extension: '.mjs', category: 'application', description: 'JavaScript (application)', binary: false },
+  { mimeType: 'application/typescript', extension: '.mts', category: 'application', description: 'TypeScript (application)', binary: false },
+  { mimeType: 'application/wasm', extension: '.wasm', category: 'application', description: 'WebAssembly', binary: true },
+  { mimeType: 'application/octet-stream', extension: '.bin', category: 'application', description: 'Binary data', binary: true },
+];
+
+// ============================================================================
+// Sample content generators
+// ============================================================================
+
+/**
+ * Creates minimal valid sample content for a given MIME type.
+ * For binary formats, creates the smallest valid file possible.
+ * For text formats, creates simple sample text content.
+ */
+function createSampleContent(entry: MimeTypeEntry): Buffer {
+  if (!entry.binary) {
+    return createTextContent(entry);
+  }
+  return createBinaryContent(entry);
+}
+
+function createTextContent(entry: MimeTypeEntry): Buffer {
+  const samples: Record<string, string> = {
+    'text/plain': 'Hello, world. This is a test file.\n',
+    'text/html': '<!DOCTYPE html><html><head><title>Test</title></head><body><p>Hello</p></body></html>',
+    'text/css': 'body { color: black; background: white; }',
+    'text/csv': 'name,age,city\nAlice,30,NYC\nBob,25,LA\n',
+    'text/markdown': '# Test\n\nThis is a **test** markdown file.\n',
+    'text/xml': '<?xml version="1.0"?><root><item>test</item></root>',
+    'text/x-python': 'def hello():\n    print("Hello, world!")\n\nhello()\n',
+    'text/javascript': 'function hello() { console.log("Hello, world!"); }\nhello();\n',
+    'text/x-typescript': 'function hello(): void { console.log("Hello, world!"); }\nhello();\n',
+    'text/x-c': '#include <stdio.h>\nint main() { printf("Hello\\n"); return 0; }\n',
+    'text/x-c++src': '#include <iostream>\nint main() { std::cout << "Hello" << std::endl; return 0; }\n',
+    'text/x-java': 'public class Test { public static void main(String[] args) { System.out.println("Hello"); } }\n',
+    'text/x-go': 'package main\nimport "fmt"\nfunc main() { fmt.Println("Hello") }\n',
+    'text/x-rust': 'fn main() { println!("Hello, world!"); }\n',
+    'text/x-ruby': 'puts "Hello, world!"\n',
+    'text/x-php': '<?php echo "Hello, world!"; ?>\n',
+    'text/x-swift': 'print("Hello, world!")\n',
+    'text/x-kotlin': 'fun main() { println("Hello, world!") }\n',
+    'text/x-scala': 'object Main extends App { println("Hello, world!") }\n',
+    'text/x-perl': 'print "Hello, world!\\n";\n',
+    'text/x-lua': 'print("Hello, world!")\n',
+    'text/x-erlang': '-module(hello).\n-export([hello/0]).\nhello() -> io:format("Hello~n").\n',
+    'text/x-haskell': 'main :: IO ()\nmain = putStrLn "Hello, world!"\n',
+    'text/x-clojure': '(println "Hello, world!")\n',
+    'text/x-elixir': 'IO.puts "Hello, world!"\n',
+    'text/x-shellscript': '#!/bin/bash\necho "Hello, world!"\n',
+    'text/x-sql': 'SELECT 1 AS test;\n',
+    'text/x-diff': '--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n',
+    'text/x-yaml': 'name: test\nversion: 1.0\n',
+    'text/x-toml': '[package]\nname = "test"\nversion = "1.0"\n',
+    'application/json': '{"name": "test", "version": 1}',
+    'application/xml': '<?xml version="1.0"?><root><item>test</item></root>',
+    'application/x-yaml': 'name: test\nversion: 1.0\n',
+    'application/graphql': 'query { user { name email } }',
+    'application/ld+json': '{"@context": "https://schema.org", "@type": "Thing", "name": "Test"}',
+    'application/javascript': 'export function hello() { console.log("Hello"); }\n',
+    'application/typescript': 'export function hello(): void { console.log("Hello"); }\n',
+    'application/rtf': '{\\rtf1\\ansi Hello, world!}',
+    'image/svg+xml': '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>',
+  };
+
+  const content = samples[entry.mimeType] || `Sample content for ${entry.mimeType} testing.\n`;
+  return Buffer.from(content, 'utf-8');
+}
+
+function createBinaryContent(entry: MimeTypeEntry): Buffer {
+  switch (entry.mimeType) {
+    case 'image/png':
+      return createMinimalPng();
+    case 'image/jpeg':
+      return createMinimalJpeg();
+    case 'image/gif':
+      return createMinimalGif();
+    case 'image/webp':
+      return createMinimalWebp();
+    case 'image/bmp':
+      return createMinimalBmp();
+    case 'image/tiff':
+      return createMinimalTiff();
+    case 'application/pdf':
+      return Buffer.from(
+        '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj xref 0 4 trailer<</Size 4/Root 1 0 R>>startxref 0 %%EOF'
+      );
+    case 'audio/wav':
+      return createMinimalWav();
+    case 'audio/mpeg':
+      return createMinimalMp3();
+    default:
+      // For binary types we can't easily generate valid content for,
+      // create a small buffer with the appropriate magic bytes if known
+      return createGenericBinaryContent(entry.mimeType);
+  }
+}
+
+// Minimal 1x1 PNG (red pixel)
+function createMinimalPng(): Buffer {
+  return Buffer.from(
+    '89504e470d0a1a0a0000000d494844520000000100000001080200' +
+    '00009001be00000000c49444154789c626460f80f0000010100' +
+    '005a18d9a4000000004945ae4260820000',
+    'hex'
+  );
+}
+
+// Minimal JPEG (1x1 red pixel)
+function createMinimalJpeg(): Buffer {
+  // Smallest valid JPEG
+  return Buffer.from(
+    'ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffc0000b080001000101011100ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc40000ffc40000ffda00080101003f00' +
+    '7b4000017ffd9',
+    'hex'
+  );
+}
+
+// Minimal GIF (1x1)
+function createMinimalGif(): Buffer {
+  return Buffer.from(
+    '47494638396101000100800000ffffff0000002c00000000010001000002024401003b',
+    'hex'
+  );
+}
+
+// Minimal WebP (1x1)
+function createMinimalWebp(): Buffer {
+  return Buffer.from(
+    '524946462400000057454250565038200018000000300100009d012a0100010001' +
+    '00034025a400030000fef39fa00000',
+    'hex'
+  );
+}
+
+// Minimal BMP (1x1 red pixel)
+function createMinimalBmp(): Buffer {
+  const buf = Buffer.alloc(58);
+  // BM header
+  buf.write('BM', 0);
+  buf.writeUInt32LE(58, 2); // file size
+  buf.writeUInt32LE(54, 10); // pixel data offset
+  // DIB header (BITMAPINFOHEADER)
+  buf.writeUInt32LE(40, 14); // header size
+  buf.writeInt32LE(1, 18); // width
+  buf.writeInt32LE(1, 22); // height
+  buf.writeUInt16LE(1, 26); // color planes
+  buf.writeUInt16LE(24, 28); // bits per pixel
+  // pixel data: blue=0, green=0, red=255, padding=0
+  buf[54] = 0; buf[55] = 0; buf[56] = 255; buf[57] = 0;
+  return buf;
+}
+
+// Minimal TIFF (1x1)
+function createMinimalTiff(): Buffer {
+  // Little-endian TIFF with 1x1 pixel
+  const buf = Buffer.alloc(122);
+  // Header
+  buf.write('II', 0); // little-endian
+  buf.writeUInt16LE(42, 2); // magic
+  buf.writeUInt32LE(8, 4); // offset to first IFD
+
+  // IFD with 8 entries at offset 8
+  let offset = 8;
+  buf.writeUInt16LE(8, offset); offset += 2; // number of entries
+
+  // ImageWidth (256) = 1
+  buf.writeUInt16LE(256, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+  // ImageLength (257) = 1
+  buf.writeUInt16LE(257, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+  // BitsPerSample (258) = 8
+  buf.writeUInt16LE(258, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(8, offset+8); offset += 12;
+  // Compression (259) = 1 (none)
+  buf.writeUInt16LE(259, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+  // PhotometricInterpretation (262) = 1 (black is zero)
+  buf.writeUInt16LE(262, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+  // StripOffsets (273) - point to pixel data
+  buf.writeUInt16LE(273, offset); buf.writeUInt16LE(4, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(120, offset+8); offset += 12;
+  // RowsPerStrip (278) = 1
+  buf.writeUInt16LE(278, offset); buf.writeUInt16LE(3, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+  // StripByteCounts (279) = 1
+  buf.writeUInt16LE(279, offset); buf.writeUInt16LE(4, offset+2); buf.writeUInt32LE(1, offset+4); buf.writeUInt32LE(1, offset+8); offset += 12;
+
+  // Next IFD = 0
+  buf.writeUInt32LE(0, offset);
+
+  // Pixel data at offset 120
+  buf[120] = 128; // gray pixel
+  return buf;
+}
+
+// Minimal WAV (silence, 1 sample)
+function createMinimalWav(): Buffer {
+  const buf = Buffer.alloc(46);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(38, 4); // chunk size
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16); // subchunk1 size
+  buf.writeUInt16LE(1, 20); // PCM
+  buf.writeUInt16LE(1, 22); // mono
+  buf.writeUInt32LE(8000, 24); // sample rate
+  buf.writeUInt32LE(16000, 28); // byte rate
+  buf.writeUInt16LE(2, 32); // block align
+  buf.writeUInt16LE(16, 34); // bits per sample
+  buf.write('data', 36);
+  buf.writeUInt32LE(2, 40); // data size
+  buf.writeInt16LE(0, 44); // one silent sample
+  return buf;
+}
+
+// Minimal MP3 frame (silence)
+function createMinimalMp3(): Buffer {
+  // MP3 sync word + minimal frame header for MPEG1 Layer3 128kbps 44100Hz stereo
+  // Frame header: 0xFFFB9004
+  const frameHeader = Buffer.from('fffb9004', 'hex');
+  // Pad with zeros for the frame body (417 bytes for 128kbps/44100Hz)
+  const frameBody = Buffer.alloc(413);
+  return Buffer.concat([frameHeader, frameBody]);
+}
+
+// Generic binary content with appropriate magic bytes
+function createGenericBinaryContent(mimeType: string): Buffer {
+  const magicBytes: Record<string, Buffer> = {
+    'audio/flac': Buffer.from('664c614300000022', 'hex'), // fLaC + streaminfo header
+    'audio/aac': Buffer.from('fff1508004', 'hex'), // AAC ADTS header
+    'audio/ogg': Buffer.from('4f676753', 'hex'), // OggS
+    'audio/mp4': Buffer.from('0000001c667479704d344120', 'hex'), // ftyp M4A
+    'audio/webm': Buffer.from('1a45dfa3', 'hex'), // EBML header
+    'audio/x-aiff': Buffer.from('464f524d00000000414946462020', 'hex'), // FORM...AIFF
+    'audio/opus': Buffer.from('4f676753', 'hex'), // OggS
+    'audio/amr': Buffer.from('2321414d520a', 'hex'), // #!AMR\n
+    'audio/midi': Buffer.from('4d546864', 'hex'), // MThd
+    'video/mp4': Buffer.from('000000186674797069736f6d', 'hex'), // ftyp isom
+    'video/webm': Buffer.from('1a45dfa3', 'hex'), // EBML header
+    'video/quicktime': Buffer.from('0000001466747970717420', 'hex'), // ftyp qt
+    'video/x-msvideo': Buffer.from('524946460000000041564920', 'hex'), // RIFF...AVI
+    'video/mpeg': Buffer.from('000001ba', 'hex'), // MPEG PS
+    'video/x-matroska': Buffer.from('1a45dfa3', 'hex'), // EBML header
+    'video/x-flv': Buffer.from('464c5601', 'hex'), // FLV\x01
+    'video/3gpp': Buffer.from('0000001866747970336770', 'hex'), // ftyp 3gp
+    'video/3gpp2': Buffer.from('0000001866747970336732', 'hex'), // ftyp 3g2
+    'video/x-ms-wmv': Buffer.from('3026b2758e66cf11', 'hex'), // ASF header
+    'application/msword': Buffer.from('d0cf11e0a1b11ae1', 'hex'), // OLE2
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': Buffer.from('504b0304', 'hex'), // PK zip
+    'application/vnd.ms-excel': Buffer.from('d0cf11e0a1b11ae1', 'hex'), // OLE2
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': Buffer.from('504b0304', 'hex'), // PK zip
+    'application/vnd.ms-powerpoint': Buffer.from('d0cf11e0a1b11ae1', 'hex'), // OLE2
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': Buffer.from('504b0304', 'hex'), // PK zip
+    'application/epub+zip': Buffer.from('504b0304', 'hex'), // PK zip
+    'application/zip': Buffer.from('504b0304', 'hex'), // PK zip
+    'application/gzip': Buffer.from('1f8b0800', 'hex'), // gzip
+    'application/x-tar': Buffer.alloc(512), // tar needs 512-byte blocks
+    'application/wasm': Buffer.from('0061736d01000000', 'hex'), // \0asm
+    'image/x-icon': Buffer.from('00000100010001000100', 'hex'), // ICO header
+    'image/heic': Buffer.from('0000001c667479706865696300', 'hex'), // ftyp heic
+    'image/heif': Buffer.from('0000001c667479706d696631', 'hex'), // ftyp mif1
+    'image/avif': Buffer.from('0000001c6674797061766966', 'hex'), // ftyp avif
+    'font/woff': Buffer.from('774f4646', 'hex'), // wOFF
+    'font/woff2': Buffer.from('774f4632', 'hex'), // wOF2
+    'font/ttf': Buffer.from('0001000000', 'hex'), // TTF header
+    'font/otf': Buffer.from('4f54544f00', 'hex'), // OTTO
+  };
+
+  const magic = magicBytes[mimeType];
+  if (magic) {
+    // Pad to at least 64 bytes to be more realistic
+    const padding = Buffer.alloc(Math.max(0, 64 - magic.length));
+    return Buffer.concat([magic, padding]);
+  }
+
+  // Fallback: 64 bytes of zeros
+  return Buffer.alloc(64);
+}
+
+// ============================================================================
+// Probe Engine
+// ============================================================================
+
+class MimeTypeProber {
+  private client: GoogleGenAI;
+  private model: string;
+  private sampleDir: string;
+  private results: ProbeResult[] = [];
+
+  constructor(apiKey: string, model: string = 'gemini-2.0-flash') {
+    this.client = new GoogleGenAI({ apiKey, vertexai: false });
+    this.model = model;
+    this.sampleDir = path.join(__dirname, '.probe-samples');
+  }
+
+  async probe(options: {
+    methods?: ('inline' | 'file-api')[];
+    categories?: string[];
+  } = {}): Promise<ProbeReport> {
+    const startTime = Date.now();
+    const methods = options.methods ?? ['inline', 'file-api'];
+    const categories = options.categories;
+
+    let entries = MIME_TYPE_CATALOG;
+    if (categories) {
+      entries = entries.filter(e => categories.includes(e.category));
+    }
+
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('MIME Type Probe');
+    console.log(`${'='.repeat(60)}`);
+    console.log(`Model: ${this.model}`);
+    console.log(`MIME types to test: ${entries.length}`);
+    console.log(`Methods: ${methods.join(', ')}`);
+    console.log(`${'='.repeat(60)}\n`);
+
+    // Ensure sample directory exists
+    if (!fs.existsSync(this.sampleDir)) {
+      fs.mkdirSync(this.sampleDir, { recursive: true });
+    }
+
+    try {
+      let count = 0;
+      for (const entry of entries) {
+        count++;
+        process.stdout.write(`\r[${count}/${entries.length}] Testing ${entry.mimeType.padEnd(65)}`);
+
+        const result: ProbeResult = {
+          mimeType: entry.mimeType,
+          extension: entry.extension,
+          category: entry.category,
+          description: entry.description,
+          inline: { status: 'skip', message: 'Not tested' },
+          fileApi: { status: 'skip', message: 'Not tested' },
+        };
+
+        const sampleContent = createSampleContent(entry);
+
+        if (methods.includes('inline')) {
+          result.inline = await this.testInline(entry, sampleContent);
+        }
+
+        if (methods.includes('file-api')) {
+          result.fileApi = await this.testFileApi(entry, sampleContent);
+        }
+
+        this.results.push(result);
+      }
+
+      console.log('\r' + ' '.repeat(80) + '\r'); // Clear progress line
+    } finally {
+      // Cleanup sample directory
+      if (fs.existsSync(this.sampleDir)) {
+        fs.rmSync(this.sampleDir, { recursive: true, force: true });
+      }
+    }
+
+    const duration = Date.now() - startTime;
+    return this.generateReport(duration);
+  }
+
+  /**
+   * Test inline base64 upload via generateContent
+   */
+  private async testInline(entry: MimeTypeEntry, content: Buffer): Promise<TestOutcome> {
+    const start = Date.now();
+    try {
+      const base64Data = content.toString('base64');
+
+      await this.client.models.generateContent({
+        model: this.model,
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                inlineData: {
+                  mimeType: entry.mimeType,
+                  data: base64Data,
+                },
+              },
+              { text: 'Acknowledge this file with one word: OK' },
+            ],
+          },
+        ],
+      });
+
+      return {
+        status: 'pass',
+        message: 'Accepted as inline base64',
+        durationMs: Date.now() - start,
+      };
+    } catch (error: unknown) {
+      return {
+        status: 'fail',
+        message: sanitizeError(error),
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  /**
+   * Test File API upload via client.files.upload
+   */
+  private async testFileApi(entry: MimeTypeEntry, content: Buffer): Promise<TestOutcome> {
+    const start = Date.now();
+    const filePath = path.join(this.sampleDir, `test${entry.extension}`);
+    let uploadedFileName: string | undefined;
+
+    try {
+      // Write sample file to disk
+      fs.writeFileSync(filePath, content);
+
+      const file = await this.client.files.upload({
+        file: filePath,
+        config: {
+          mimeType: entry.mimeType,
+          displayName: `probe-test${entry.extension}`,
+        },
+      });
+
+      uploadedFileName = file.name;
+
+      return {
+        status: 'pass',
+        message: 'Accepted by File API',
+        durationMs: Date.now() - start,
+      };
+    } catch (error: unknown) {
+      return {
+        status: 'fail',
+        message: sanitizeError(error),
+        durationMs: Date.now() - start,
+      };
+    } finally {
+      // Cleanup: delete the uploaded file from the API
+      if (uploadedFileName) {
+        try {
+          await this.client.files.delete({ name: uploadedFileName });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+      // Cleanup: delete local temp file
+      try {
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  private generateReport(durationMs: number): ProbeReport {
+    const inline = { passed: 0, failed: 0, skipped: 0 };
+    const fileApi = { passed: 0, failed: 0, skipped: 0 };
+
+    for (const r of this.results) {
+      if (r.inline.status === 'pass') inline.passed++;
+      else if (r.inline.status === 'fail') inline.failed++;
+      else inline.skipped++;
+
+      if (r.fileApi.status === 'pass') fileApi.passed++;
+      else if (r.fileApi.status === 'fail') fileApi.failed++;
+      else fileApi.skipped++;
+    }
+
+    return {
+      timestamp: new Date().toISOString(),
+      model: this.model,
+      totalMimeTypes: this.results.length,
+      methods: { inline, fileApi },
+      results: this.results,
+      durationMs,
+    };
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function sanitizeError(error: unknown): string {
+  const msg = (error as Error)?.message ?? String(error);
+  // Truncate very long error messages
+  return msg.length > 300 ? msg.substring(0, 300) + '...' : msg;
+}
+
+function printReport(report: ProbeReport): void {
+  console.log(`\n${'='.repeat(70)}`);
+  console.log('MIME Type Probe Report');
+  console.log(`${'='.repeat(70)}\n`);
+
+  console.log(`Timestamp:       ${report.timestamp}`);
+  console.log(`Model:           ${report.model}`);
+  console.log(`Total tested:    ${report.totalMimeTypes}`);
+  console.log(`Duration:        ${(report.durationMs / 1000).toFixed(1)}s\n`);
+
+  // Summary table
+  console.log('Method Summary:');
+  console.log(`  Inline (base64): ${report.methods.inline.passed} pass, ${report.methods.inline.failed} fail, ${report.methods.inline.skipped} skip`);
+  console.log(`  File API:        ${report.methods.fileApi.passed} pass, ${report.methods.fileApi.failed} fail, ${report.methods.fileApi.skipped} skip`);
+  console.log();
+
+  // Results by category
+  const categories = [...new Set(report.results.map(r => r.category))];
+  for (const cat of categories) {
+    const catResults = report.results.filter(r => r.category === cat);
+    console.log(`\n--- ${cat.toUpperCase()} ---`);
+    console.log(`${'MIME Type'.padEnd(55)} ${'Inline'.padEnd(10)} ${'File API'.padEnd(10)}`);
+    console.log(`${'-'.repeat(55)} ${'-'.repeat(10)} ${'-'.repeat(10)}`);
+
+    for (const r of catResults) {
+      const inlineIcon = r.inline.status === 'pass' ? 'PASS' : r.inline.status === 'fail' ? 'FAIL' : 'SKIP';
+      const fileIcon = r.fileApi.status === 'pass' ? 'PASS' : r.fileApi.status === 'fail' ? 'FAIL' : 'SKIP';
+      console.log(`${r.mimeType.padEnd(55)} ${inlineIcon.padEnd(10)} ${fileIcon.padEnd(10)}`);
+    }
+  }
+
+  // Failed details
+  const inlineFails = report.results.filter(r => r.inline.status === 'fail');
+  const fileApiFails = report.results.filter(r => r.fileApi.status === 'fail');
+
+  if (inlineFails.length > 0) {
+    console.log(`\n\n--- INLINE FAILURES (${inlineFails.length}) ---`);
+    for (const r of inlineFails) {
+      console.log(`  ${r.mimeType}: ${r.inline.message}`);
+    }
+  }
+
+  if (fileApiFails.length > 0) {
+    console.log(`\n\n--- FILE API FAILURES (${fileApiFails.length}) ---`);
+    for (const r of fileApiFails) {
+      console.log(`  ${r.mimeType}: ${r.fileApi.message}`);
+    }
+  }
+
+  console.log(`\n${'='.repeat(70)}\n`);
+}
+
+// ============================================================================
+// CLI Entry Point
+// ============================================================================
+
+function parseArgs(): { methods?: ('inline' | 'file-api')[]; categories?: string[] } {
+  const args = process.argv.slice(2);
+  const options: { methods?: ('inline' | 'file-api')[]; categories?: string[] } = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--method' && args[i + 1]) {
+      const method = args[i + 1] as 'inline' | 'file-api';
+      if (['inline', 'file-api'].includes(method)) {
+        options.methods = [method];
+      }
+      i++;
+    } else if (args[i] === '--category' && args[i + 1]) {
+      options.categories = args[i + 1].split(',');
+      i++;
+    }
+  }
+
+  return options;
+}
+
+function getApiKey(): string {
+  // 1. Environment variables
+  const envKey = process.env.GEMINI_API_KEY || process.env.GEMINI_DEEP_RESEARCH_API_KEY;
+  if (envKey) return envKey;
+
+  // 2. Config file (~/.config/gemini-utils/config.json)
+  const configDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const configPath = path.join(configDir, 'gemini-utils', 'config.json');
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (parsed.apiKey) return parsed.apiKey;
+    } catch { /* ignore */ }
+  }
+
+  // 3. .env file (~/.config/gemini-utils/.env)
+  const envPath = path.join(configDir, 'gemini-utils', '.env');
+  if (fs.existsSync(envPath)) {
+    try {
+      const content = fs.readFileSync(envPath, 'utf-8');
+      const match = content.match(/GEMINI_API_KEY\s*=\s*["']?([^"'\n]+)/);
+      if (match) return match[1].trim();
+    } catch { /* ignore */ }
+  }
+
+  console.error('Error: API key not found.');
+  console.error('Please set GEMINI_API_KEY env var or add it to ~/.config/gemini-utils/config.json');
+  process.exit(1);
+}
+
+async function main() {
+  const apiKey = getApiKey();
+
+  const options = parseArgs();
+
+  console.log('Starting MIME Type Probe...');
+  console.log('This tests which MIME types the Gemini API actually accepts.\n');
+
+  try {
+    const prober = new MimeTypeProber(apiKey);
+    const report = await prober.probe(options);
+
+    printReport(report);
+
+    // Save report
+    const reportPath = path.join(__dirname, 'probe-mime-types-report.json');
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    console.log(`Report saved to: ${reportPath}`);
+
+    // Exit with error code if everything failed
+    const totalPassed = report.methods.inline.passed + report.methods.fileApi.passed;
+    if (totalPassed === 0) {
+      console.error('\nNo MIME types passed any test - check API key and connectivity.');
+      process.exit(1);
+    }
+  } catch (error: unknown) {
+    console.error('\nFatal error during probe:');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+const isMainModule = (() => {
+  try {
+    const scriptPath = realpathSync(fileURLToPath(import.meta.url));
+    const argPath = process.argv[1] ? realpathSync(process.argv[1]) : '';
+    return scriptPath === argPath;
+  } catch {
+    return false;
+  }
+})();
+if (isMainModule) {
+  main().catch((error) => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+export { MimeTypeProber, MIME_TYPE_CATALOG };
+export type { ProbeReport, ProbeResult, MimeTypeEntry, TestOutcome };

--- a/scripts/probe-mime-types.ts
+++ b/scripts/probe-mime-types.ts
@@ -398,12 +398,22 @@ function createMinimalPng(): Buffer {
 
 // Minimal JPEG (1x1 red pixel)
 function createMinimalJpeg(): Buffer {
-  // Smallest valid JPEG
-  return Buffer.from(
-    'ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffc0000b080001000101011100ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc40000ffc40000ffda00080101003f00' +
-    '7b4000017ffd9',
-    'hex'
-  );
+  // Smallest valid JPEG - verified even-length hex
+  const hex =
+    'ffd8ffe000104a46494600010100000100010000' +
+    'ffdb004300080606070605080707070909080a0c' +
+    '140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c' +
+    '20242e2720222c231c1c2837292c30313434341f' +
+    '27393d38323c2e333432' +
+    'ffc0000b080001000101011100' +
+    'ffc4001f0000010501010101010100000000000000000102030405060708090a0b' +
+    'ffc40000ffc40000' +
+    'ffda00080101003f007b400001' +
+    'ffd9';
+  if (hex.length % 2 !== 0) {
+    throw new Error(`Invalid JPEG hex constant: odd length ${hex.length}`);
+  }
+  return Buffer.from(hex, 'hex');
 }
 
 // Minimal GIF (1x1)

--- a/scripts/probe-mime-types.ts
+++ b/scripts/probe-mime-types.ts
@@ -34,6 +34,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { fileURLToPath } from 'url';
 import { realpathSync } from 'fs';
+import type { ErrorClass } from '../src/support-registry/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -51,8 +52,6 @@ interface MimeTypeEntry {
   /** Whether this requires binary content (vs text) */
   binary: boolean;
 }
-
-type ErrorClass = 'mime_rejected' | 'content_invalid' | 'rate_limited' | 'unknown';
 
 interface ProbeResult {
   mimeType: string;

--- a/scripts/probe-mime-types.ts
+++ b/scripts/probe-mime-types.ts
@@ -16,6 +16,8 @@
  *   npx tsx scripts/probe-mime-types.ts --method inline
  *   npx tsx scripts/probe-mime-types.ts --method file-api
  *   npx tsx scripts/probe-mime-types.ts --category image
+ *   npx tsx scripts/probe-mime-types.ts --model gemini-3.0-flash-preview
+ *   npx tsx scripts/probe-mime-types.ts --model gemini-3.0-flash-preview,gemini-2.0-flash
  *
  * Environment:
  *   GEMINI_API_KEY - Required Gemini API key
@@ -23,6 +25,7 @@
  * Output:
  *   - Console report with summary
  *   - JSON report saved to scripts/probe-mime-types-report.json
+ *   - Support matrix saved to src/generated/gemini-support-matrix.json
  */
 
 import { GoogleGenAI } from '@google/genai';
@@ -49,6 +52,8 @@ interface MimeTypeEntry {
   binary: boolean;
 }
 
+type ErrorClass = 'mime_rejected' | 'content_invalid' | 'rate_limited' | 'unknown';
+
 interface ProbeResult {
   mimeType: string;
   extension: string;
@@ -62,6 +67,7 @@ interface TestOutcome {
   status: 'pass' | 'fail' | 'skip';
   message: string;
   durationMs?: number;
+  errorClass?: ErrorClass;
 }
 
 interface ProbeReport {
@@ -74,6 +80,107 @@ interface ProbeReport {
   };
   results: ProbeResult[];
   durationMs: number;
+}
+
+interface MultiModelProbeReport {
+  timestamp: string;
+  models: string[];
+  modelReports: Record<string, ProbeReport>;
+  durationMs: number;
+}
+
+/** Shape of each entry in the generated support matrix. */
+interface MatrixEntry {
+  category: string;
+  extension: string;
+  description: string;
+  models: Record<string, {
+    inline: boolean;
+    fileApi: boolean;
+    inlineErrorClass?: ErrorClass;
+    fileApiErrorClass?: ErrorClass;
+  }>;
+}
+
+// ============================================================================
+// Error Classification
+// ============================================================================
+
+function classifyError(message: string): ErrorClass {
+  const lower = message.toLowerCase();
+
+  if (lower.includes('which is not supported') && lower.includes('mimetype')) {
+    return 'mime_rejected';
+  }
+  if (lower.includes('is not supported. update the mimetype')) {
+    return 'mime_rejected';
+  }
+  if (lower.includes('not valid') || lower.includes('provided image is not valid')) {
+    return 'content_invalid';
+  }
+  if (lower.includes('resource_exhausted') || lower.includes('429') || lower.includes('quota')) {
+    return 'rate_limited';
+  }
+
+  return 'unknown';
+}
+
+// ============================================================================
+// Rate Limiter
+// ============================================================================
+
+class RateLimiter {
+  private timestamps: number[] = [];
+  private readonly maxPerMinute: number;
+  private readonly maxRetries: number;
+
+  constructor(maxPerMinute = 30, maxRetries = 3) {
+    this.maxPerMinute = maxPerMinute;
+    this.maxRetries = maxRetries;
+  }
+
+  async acquire(): Promise<void> {
+    const now = Date.now();
+    // Remove timestamps older than 1 minute
+    this.timestamps = this.timestamps.filter(t => now - t < 60_000);
+
+    if (this.timestamps.length >= this.maxPerMinute) {
+      const oldestInWindow = this.timestamps[0];
+      const waitMs = 60_000 - (now - oldestInWindow) + 100;
+      if (waitMs > 0) {
+        await this.sleep(waitMs);
+      }
+    }
+
+    this.timestamps.push(Date.now());
+    // Small delay between requests
+    await this.sleep(200);
+  }
+
+  async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        await this.acquire();
+        return await fn();
+      } catch (error: unknown) {
+        lastError = error;
+        const msg = (error as Error)?.message ?? String(error);
+        if (classifyError(msg) === 'rate_limited' && attempt < this.maxRetries) {
+          const backoff = Math.pow(2, attempt + 1) * 1000;
+          console.log(`\n  Rate limited, retrying in ${backoff / 1000}s (attempt ${attempt + 1}/${this.maxRetries})...`);
+          await this.sleep(backoff);
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw lastError;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 }
 
 // ============================================================================
@@ -465,11 +572,13 @@ class MimeTypeProber {
   private model: string;
   private sampleDir: string;
   private results: ProbeResult[] = [];
+  private rateLimiter: RateLimiter;
 
   constructor(apiKey: string, model: string = 'gemini-2.0-flash') {
     this.client = new GoogleGenAI({ apiKey, vertexai: false });
     this.model = model;
     this.sampleDir = path.join(__dirname, '.probe-samples');
+    this.rateLimiter = new RateLimiter(30, 3);
   }
 
   async probe(options: {
@@ -497,6 +606,9 @@ class MimeTypeProber {
     if (!fs.existsSync(this.sampleDir)) {
       fs.mkdirSync(this.sampleDir, { recursive: true });
     }
+
+    // Reset results for this probe run
+    this.results = [];
 
     try {
       let count = 0;
@@ -546,22 +658,24 @@ class MimeTypeProber {
     try {
       const base64Data = content.toString('base64');
 
-      await this.client.models.generateContent({
-        model: this.model,
-        contents: [
-          {
-            role: 'user',
-            parts: [
-              {
-                inlineData: {
-                  mimeType: entry.mimeType,
-                  data: base64Data,
+      await this.rateLimiter.withRetry(async () => {
+        await this.client.models.generateContent({
+          model: this.model,
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: entry.mimeType,
+                    data: base64Data,
+                  },
                 },
-              },
-              { text: 'Acknowledge this file with one word: OK' },
-            ],
-          },
-        ],
+                { text: 'Acknowledge this file with one word: OK' },
+              ],
+            },
+          ],
+        });
       });
 
       return {
@@ -570,10 +684,12 @@ class MimeTypeProber {
         durationMs: Date.now() - start,
       };
     } catch (error: unknown) {
+      const message = sanitizeError(error);
       return {
         status: 'fail',
-        message: sanitizeError(error),
+        message,
         durationMs: Date.now() - start,
+        errorClass: classifyError(message),
       };
     }
   }
@@ -590,12 +706,14 @@ class MimeTypeProber {
       // Write sample file to disk
       fs.writeFileSync(filePath, content);
 
-      const file = await this.client.files.upload({
-        file: filePath,
-        config: {
-          mimeType: entry.mimeType,
-          displayName: `probe-test${entry.extension}`,
-        },
+      const file = await this.rateLimiter.withRetry(async () => {
+        return await this.client.files.upload({
+          file: filePath,
+          config: {
+            mimeType: entry.mimeType,
+            displayName: `probe-test${entry.extension}`,
+          },
+        });
       });
 
       uploadedFileName = file.name;
@@ -606,10 +724,12 @@ class MimeTypeProber {
         durationMs: Date.now() - start,
       };
     } catch (error: unknown) {
+      const message = sanitizeError(error);
       return {
         status: 'fail',
-        message: sanitizeError(error),
+        message,
         durationMs: Date.now() - start,
+        errorClass: classifyError(message),
       };
     } finally {
       // Cleanup: delete the uploaded file from the API
@@ -652,6 +772,60 @@ class MimeTypeProber {
       durationMs,
     };
   }
+}
+
+// ============================================================================
+// Matrix Generation
+// ============================================================================
+
+/**
+ * Transform probe reports into the support matrix JSON.
+ * - content_invalid errors are treated as "likely supported" (content was bad, not the type).
+ * - Sorted by MIME type key for deterministic diffs.
+ */
+function generateSupportMatrix(
+  modelReports: Record<string, ProbeReport>
+): Record<string, MatrixEntry> {
+  const matrix: Record<string, MatrixEntry> = {};
+
+  for (const [modelName, report] of Object.entries(modelReports)) {
+    for (const result of report.results) {
+      if (!matrix[result.mimeType]) {
+        matrix[result.mimeType] = {
+          category: result.category,
+          extension: result.extension,
+          description: result.description,
+          models: {},
+        };
+      }
+
+      const inlineSupported =
+        result.inline.status === 'pass' ||
+        result.inline.errorClass === 'content_invalid';
+      const fileApiSupported =
+        result.fileApi.status === 'pass' ||
+        result.fileApi.errorClass === 'content_invalid';
+
+      matrix[result.mimeType].models[modelName] = {
+        inline: inlineSupported,
+        fileApi: fileApiSupported,
+        ...(result.inline.status === 'fail' && result.inline.errorClass
+          ? { inlineErrorClass: result.inline.errorClass }
+          : {}),
+        ...(result.fileApi.status === 'fail' && result.fileApi.errorClass
+          ? { fileApiErrorClass: result.fileApi.errorClass }
+          : {}),
+      };
+    }
+  }
+
+  // Sort by MIME type key for deterministic diffs
+  const sorted: Record<string, MatrixEntry> = {};
+  for (const key of Object.keys(matrix).sort()) {
+    sorted[key] = matrix[key];
+  }
+
+  return sorted;
 }
 
 // ============================================================================
@@ -702,14 +876,16 @@ function printReport(report: ProbeReport): void {
   if (inlineFails.length > 0) {
     console.log(`\n\n--- INLINE FAILURES (${inlineFails.length}) ---`);
     for (const r of inlineFails) {
-      console.log(`  ${r.mimeType}: ${r.inline.message}`);
+      const cls = r.inline.errorClass ? ` [${r.inline.errorClass}]` : '';
+      console.log(`  ${r.mimeType}${cls}: ${r.inline.message}`);
     }
   }
 
   if (fileApiFails.length > 0) {
     console.log(`\n\n--- FILE API FAILURES (${fileApiFails.length}) ---`);
     for (const r of fileApiFails) {
-      console.log(`  ${r.mimeType}: ${r.fileApi.message}`);
+      const cls = r.fileApi.errorClass ? ` [${r.fileApi.errorClass}]` : '';
+      console.log(`  ${r.mimeType}${cls}: ${r.fileApi.message}`);
     }
   }
 
@@ -720,9 +896,19 @@ function printReport(report: ProbeReport): void {
 // CLI Entry Point
 // ============================================================================
 
-function parseArgs(): { methods?: ('inline' | 'file-api')[]; categories?: string[] } {
+function parseArgs(): {
+  methods?: ('inline' | 'file-api')[];
+  categories?: string[];
+  models: string[];
+} {
   const args = process.argv.slice(2);
-  const options: { methods?: ('inline' | 'file-api')[]; categories?: string[] } = {};
+  const options: {
+    methods?: ('inline' | 'file-api')[];
+    categories?: string[];
+    models: string[];
+  } = {
+    models: ['gemini-3.0-flash-preview'],
+  };
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--method' && args[i + 1]) {
@@ -733,6 +919,9 @@ function parseArgs(): { methods?: ('inline' | 'file-api')[]; categories?: string
       i++;
     } else if (args[i] === '--category' && args[i + 1]) {
       options.categories = args[i + 1].split(',');
+      i++;
+    } else if (args[i] === '--model' && args[i + 1]) {
+      options.models = args[i + 1].split(',').map(m => m.trim());
       i++;
     }
   }
@@ -772,25 +961,64 @@ function getApiKey(): string {
 
 async function main() {
   const apiKey = getApiKey();
-
   const options = parseArgs();
 
   console.log('Starting MIME Type Probe...');
   console.log('This tests which MIME types the Gemini API actually accepts.\n');
 
+  const overallStart = Date.now();
+  const modelReports: Record<string, ProbeReport> = {};
+
   try {
-    const prober = new MimeTypeProber(apiKey);
-    const report = await prober.probe(options);
+    for (const model of options.models) {
+      console.log(`\nProbing model: ${model}`);
+      const prober = new MimeTypeProber(apiKey, model);
+      const report = await prober.probe({
+        methods: options.methods,
+        categories: options.categories,
+      });
 
-    printReport(report);
+      modelReports[model] = report;
+      printReport(report);
+    }
 
-    // Save report
+    const overallDuration = Date.now() - overallStart;
+
+    // Build multi-model report
+    const multiReport: MultiModelProbeReport = {
+      timestamp: new Date().toISOString(),
+      models: options.models,
+      modelReports,
+      durationMs: overallDuration,
+    };
+
+    // Save human-readable report (backward compatible)
     const reportPath = path.join(__dirname, 'probe-mime-types-report.json');
-    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    fs.writeFileSync(reportPath, JSON.stringify(multiReport, null, 2));
     console.log(`Report saved to: ${reportPath}`);
 
+    // Generate and save support matrix
+    const matrix = generateSupportMatrix(modelReports);
+    const matrixPath = path.join(__dirname, '..', 'src', 'generated', 'gemini-support-matrix.json');
+    fs.mkdirSync(path.dirname(matrixPath), { recursive: true });
+    fs.writeFileSync(matrixPath, JSON.stringify(matrix, null, 2) + '\n');
+    console.log(`Support matrix saved to: ${matrixPath}`);
+
+    // Summary
+    const matrixEntries = Object.keys(matrix).length;
+    const supportedInline = Object.values(matrix).filter(e =>
+      Object.values(e.models).some(m => m.inline)
+    ).length;
+    const supportedFileApi = Object.values(matrix).filter(e =>
+      Object.values(e.models).some(m => m.fileApi)
+    ).length;
+    console.log(`\nMatrix: ${matrixEntries} MIME types, ${supportedInline} inline-capable, ${supportedFileApi} file-api-capable`);
+
     // Exit with error code if everything failed
-    const totalPassed = report.methods.inline.passed + report.methods.fileApi.passed;
+    const totalPassed = Object.values(modelReports).reduce(
+      (sum, r) => sum + r.methods.inline.passed + r.methods.fileApi.passed,
+      0
+    );
     if (totalPassed === 0) {
       console.error('\nNo MIME types passed any test - check API key and connectivity.');
       process.exit(1);
@@ -819,5 +1047,5 @@ if (isMainModule) {
   });
 }
 
-export { MimeTypeProber, MIME_TYPE_CATALOG };
-export type { ProbeReport, ProbeResult, MimeTypeEntry, TestOutcome };
+export { MimeTypeProber, MIME_TYPE_CATALOG, RateLimiter, classifyError, generateSupportMatrix };
+export type { ProbeReport, ProbeResult, MimeTypeEntry, TestOutcome, MultiModelProbeReport, ErrorClass };

--- a/src/generated/gemini-support-matrix.json
+++ b/src/generated/gemini-support-matrix.json
@@ -1,0 +1,1046 @@
+{
+  "application/epub+zip": {
+    "category": "document",
+    "extension": ".epub",
+    "description": "EPUB ebook",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/graphql": {
+    "category": "data",
+    "extension": ".graphql",
+    "description": "GraphQL",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/gzip": {
+    "category": "archive",
+    "extension": ".gz",
+    "description": "GZIP archive",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/javascript": {
+    "category": "application",
+    "extension": ".mjs",
+    "description": "JavaScript (application)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/json": {
+    "category": "data",
+    "extension": ".json",
+    "description": "JSON",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/ld+json": {
+    "category": "data",
+    "extension": ".jsonld",
+    "description": "JSON-LD",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/msword": {
+    "category": "document",
+    "extension": ".doc",
+    "description": "Word document (legacy)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/octet-stream": {
+    "category": "application",
+    "extension": ".bin",
+    "description": "Binary data",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/pdf": {
+    "category": "document",
+    "extension": ".pdf",
+    "description": "PDF document",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/rtf": {
+    "category": "document",
+    "extension": ".rtf",
+    "description": "Rich Text Format",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/typescript": {
+    "category": "application",
+    "extension": ".mts",
+    "description": "TypeScript (application)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/vnd.ms-excel": {
+    "category": "document",
+    "extension": ".xls",
+    "description": "Excel spreadsheet (legacy)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/vnd.ms-powerpoint": {
+    "category": "document",
+    "extension": ".ppt",
+    "description": "PowerPoint (legacy)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
+    "category": "document",
+    "extension": ".pptx",
+    "description": "PowerPoint (OOXML)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+    "category": "document",
+    "extension": ".xlsx",
+    "description": "Excel spreadsheet (OOXML)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+    "category": "document",
+    "extension": ".docx",
+    "description": "Word document (OOXML)",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/wasm": {
+    "category": "application",
+    "extension": ".wasm",
+    "description": "WebAssembly",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/x-tar": {
+    "category": "archive",
+    "extension": ".tar",
+    "description": "TAR archive",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/x-yaml": {
+    "category": "data",
+    "extension": ".yamldata",
+    "description": "YAML data",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/xml": {
+    "category": "data",
+    "extension": ".xmldata",
+    "description": "XML data",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "application/zip": {
+    "category": "archive",
+    "extension": ".zip",
+    "description": "ZIP archive",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/aac": {
+    "category": "audio",
+    "extension": ".aac",
+    "description": "AAC audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/amr": {
+    "category": "audio",
+    "extension": ".amr",
+    "description": "AMR audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/flac": {
+    "category": "audio",
+    "extension": ".flac",
+    "description": "FLAC audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/midi": {
+    "category": "audio",
+    "extension": ".mid",
+    "description": "MIDI audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/mp4": {
+    "category": "audio",
+    "extension": ".m4a",
+    "description": "M4A audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/mpeg": {
+    "category": "audio",
+    "extension": ".mp3",
+    "description": "MP3 audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/ogg": {
+    "category": "audio",
+    "extension": ".ogg",
+    "description": "OGG audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/opus": {
+    "category": "audio",
+    "extension": ".opus",
+    "description": "Opus audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/wav": {
+    "category": "audio",
+    "extension": ".wav",
+    "description": "WAV audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/webm": {
+    "category": "audio",
+    "extension": ".weba",
+    "description": "WebM audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "audio/x-aiff": {
+    "category": "audio",
+    "extension": ".aiff",
+    "description": "AIFF audio",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "font/otf": {
+    "category": "font",
+    "extension": ".otf",
+    "description": "OpenType font",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "font/ttf": {
+    "category": "font",
+    "extension": ".ttf",
+    "description": "TrueType font",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "font/woff": {
+    "category": "font",
+    "extension": ".woff",
+    "description": "WOFF font",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "font/woff2": {
+    "category": "font",
+    "extension": ".woff2",
+    "description": "WOFF2 font",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/avif": {
+    "category": "image",
+    "extension": ".avif",
+    "description": "AVIF image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/bmp": {
+    "category": "image",
+    "extension": ".bmp",
+    "description": "BMP image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/gif": {
+    "category": "image",
+    "extension": ".gif",
+    "description": "GIF image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/heic": {
+    "category": "image",
+    "extension": ".heic",
+    "description": "HEIC image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/heif": {
+    "category": "image",
+    "extension": ".heif",
+    "description": "HEIF image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/jpeg": {
+    "category": "image",
+    "extension": ".jpg",
+    "description": "JPEG image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/png": {
+    "category": "image",
+    "extension": ".png",
+    "description": "PNG image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/svg+xml": {
+    "category": "image",
+    "extension": ".svg",
+    "description": "SVG image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/tiff": {
+    "category": "image",
+    "extension": ".tiff",
+    "description": "TIFF image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/webp": {
+    "category": "image",
+    "extension": ".webp",
+    "description": "WebP image",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "image/x-icon": {
+    "category": "image",
+    "extension": ".ico",
+    "description": "ICO icon",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/css": {
+    "category": "text",
+    "extension": ".css",
+    "description": "CSS stylesheet",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/csv": {
+    "category": "text",
+    "extension": ".csv",
+    "description": "CSV data",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/html": {
+    "category": "text",
+    "extension": ".html",
+    "description": "HTML",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/javascript": {
+    "category": "text",
+    "extension": ".js",
+    "description": "JavaScript source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/markdown": {
+    "category": "text",
+    "extension": ".md",
+    "description": "Markdown",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/plain": {
+    "category": "text",
+    "extension": ".txt",
+    "description": "Plain text",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-c": {
+    "category": "text",
+    "extension": ".c",
+    "description": "C source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-c++src": {
+    "category": "text",
+    "extension": ".cpp",
+    "description": "C++ source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-clojure": {
+    "category": "text",
+    "extension": ".clj",
+    "description": "Clojure source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-diff": {
+    "category": "text",
+    "extension": ".diff",
+    "description": "Diff/patch",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-elixir": {
+    "category": "text",
+    "extension": ".ex",
+    "description": "Elixir source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-erlang": {
+    "category": "text",
+    "extension": ".erl",
+    "description": "Erlang source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-go": {
+    "category": "text",
+    "extension": ".go",
+    "description": "Go source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-haskell": {
+    "category": "text",
+    "extension": ".hs",
+    "description": "Haskell source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-java": {
+    "category": "text",
+    "extension": ".java",
+    "description": "Java source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-kotlin": {
+    "category": "text",
+    "extension": ".kt",
+    "description": "Kotlin source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-lua": {
+    "category": "text",
+    "extension": ".lua",
+    "description": "Lua source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-perl": {
+    "category": "text",
+    "extension": ".pl",
+    "description": "Perl source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-php": {
+    "category": "text",
+    "extension": ".php",
+    "description": "PHP source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-python": {
+    "category": "text",
+    "extension": ".py",
+    "description": "Python source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-ruby": {
+    "category": "text",
+    "extension": ".rb",
+    "description": "Ruby source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-rust": {
+    "category": "text",
+    "extension": ".rs",
+    "description": "Rust source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-scala": {
+    "category": "text",
+    "extension": ".scala",
+    "description": "Scala source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-shellscript": {
+    "category": "text",
+    "extension": ".sh",
+    "description": "Shell script",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-sql": {
+    "category": "text",
+    "extension": ".sql",
+    "description": "SQL",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-swift": {
+    "category": "text",
+    "extension": ".swift",
+    "description": "Swift source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-toml": {
+    "category": "text",
+    "extension": ".toml",
+    "description": "TOML",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-typescript": {
+    "category": "text",
+    "extension": ".ts",
+    "description": "TypeScript source",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/x-yaml": {
+    "category": "text",
+    "extension": ".yaml",
+    "description": "YAML",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "text/xml": {
+    "category": "text",
+    "extension": ".xml",
+    "description": "XML",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/3gpp": {
+    "category": "video",
+    "extension": ".3gp",
+    "description": "3GP video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/3gpp2": {
+    "category": "video",
+    "extension": ".3g2",
+    "description": "3GP2 video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/mp4": {
+    "category": "video",
+    "extension": ".mp4",
+    "description": "MP4 video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/mpeg": {
+    "category": "video",
+    "extension": ".mpeg",
+    "description": "MPEG video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/quicktime": {
+    "category": "video",
+    "extension": ".mov",
+    "description": "QuickTime video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/webm": {
+    "category": "video",
+    "extension": ".webm",
+    "description": "WebM video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/x-flv": {
+    "category": "video",
+    "extension": ".flv",
+    "description": "FLV video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/x-matroska": {
+    "category": "video",
+    "extension": ".mkv",
+    "description": "MKV video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/x-ms-wmv": {
+    "category": "video",
+    "extension": ".wmv",
+    "description": "WMV video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  },
+  "video/x-msvideo": {
+    "category": "video",
+    "extension": ".avi",
+    "description": "AVI video",
+    "models": {
+      "gemini-3.0-flash-preview": {
+        "inline": false,
+        "fileApi": true,
+        "inlineErrorClass": "unknown"
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,6 @@ export * from './research/index.js';
 
 // Re-export all audio-transcription module exports
 export * from './audio-transcription/index.js';
+
+// Re-export all support-registry module exports
+export * from './support-registry/index.js';

--- a/src/support-registry/extensionMap.test.ts
+++ b/src/support-registry/extensionMap.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from '@jest/globals';
+import { COMPREHENSIVE_EXTENSION_MAP, getMimeToExtensionsMap } from './extensionMap.js';
+
+describe('COMPREHENSIVE_EXTENSION_MAP', () => {
+  it('should have image extensions', () => {
+    expect(COMPREHENSIVE_EXTENSION_MAP['.png']).toBe('image/png');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.jpg']).toBe('image/jpeg');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.gif']).toBe('image/gif');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.webp']).toBe('image/webp');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.svg']).toBe('image/svg+xml');
+  });
+
+  it('should have audio extensions', () => {
+    expect(COMPREHENSIVE_EXTENSION_MAP['.mp3']).toBe('audio/mpeg');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.wav']).toBe('audio/wav');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.flac']).toBe('audio/flac');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.m4a']).toBe('audio/mp4');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.ogg']).toBe('audio/ogg');
+  });
+
+  it('should have video extensions', () => {
+    expect(COMPREHENSIVE_EXTENSION_MAP['.mp4']).toBe('video/mp4');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.webm']).toBe('video/webm');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.mov']).toBe('video/quicktime');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.avi']).toBe('video/x-msvideo');
+  });
+
+  it('should have document extensions', () => {
+    expect(COMPREHENSIVE_EXTENSION_MAP['.pdf']).toBe('application/pdf');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.docx']).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.xlsx']).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.pptx']).toBe('application/vnd.openxmlformats-officedocument.presentationml.presentation');
+  });
+
+  it('should have text/code extensions', () => {
+    expect(COMPREHENSIVE_EXTENSION_MAP['.txt']).toBe('text/plain');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.html']).toBe('text/html');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.css']).toBe('text/css');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.py']).toBe('text/x-python');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.js']).toBe('text/javascript');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.ts']).toBe('text/x-typescript');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.md']).toBe('text/markdown');
+    expect(COMPREHENSIVE_EXTENSION_MAP['.json']).toBe('application/json');
+  });
+
+  it('should have all keys lowercase with leading dots', () => {
+    for (const key of Object.keys(COMPREHENSIVE_EXTENSION_MAP)) {
+      expect(key).toMatch(/^\./);
+      expect(key).toBe(key.toLowerCase());
+    }
+  });
+
+  it('should have at least 180 entries', () => {
+    expect(Object.keys(COMPREHENSIVE_EXTENSION_MAP).length).toBeGreaterThanOrEqual(180);
+  });
+});
+
+describe('getMimeToExtensionsMap', () => {
+  it('should return correct extensions for image/jpeg', () => {
+    const map = getMimeToExtensionsMap();
+    const exts = map.get('image/jpeg');
+    expect(exts).toBeDefined();
+    expect(exts).toContain('.jpg');
+    expect(exts).toContain('.jpeg');
+  });
+
+  it('should return correct extensions for text/plain', () => {
+    const map = getMimeToExtensionsMap();
+    const exts = map.get('text/plain');
+    expect(exts).toBeDefined();
+    expect(exts).toContain('.txt');
+    expect(exts).toContain('.log');
+  });
+
+  it('should return correct extensions for audio/mpeg', () => {
+    const map = getMimeToExtensionsMap();
+    const exts = map.get('audio/mpeg');
+    expect(exts).toBeDefined();
+    expect(exts).toContain('.mp3');
+  });
+
+  it('should be cached (same instance on repeated calls)', () => {
+    const map1 = getMimeToExtensionsMap();
+    const map2 = getMimeToExtensionsMap();
+    expect(map1).toBe(map2);
+  });
+
+  it('should cover all MIME types from the extension map', () => {
+    const map = getMimeToExtensionsMap();
+    const uniqueMimes = new Set(Object.values(COMPREHENSIVE_EXTENSION_MAP));
+    expect(map.size).toBe(uniqueMimes.size);
+  });
+});

--- a/src/support-registry/extensionMap.ts
+++ b/src/support-registry/extensionMap.ts
@@ -1,0 +1,248 @@
+/**
+ * Comprehensive extension-to-MIME-type mapping for the Gemini Content API.
+ *
+ * This is an independent copy that consolidates extensions from:
+ * - file-search/mimeTypes.ts (EXTENSION_TO_MIME + TEXT_FALLBACK_EXTENSIONS)
+ * - audio-transcription/audioMimeTypes.ts (AUDIO_EXTENSION_TO_MIME)
+ * - The probe catalog (image, video, document, data, archive, font types)
+ *
+ * It does NOT delegate to or modify the existing maps in other modules.
+ */
+
+/**
+ * Comprehensive mapping of file extensions (with leading dot, lowercase) to MIME types.
+ * Covers images, audio, video, documents, text/code, structured data, archives, and fonts.
+ */
+export const COMPREHENSIVE_EXTENSION_MAP: Record<string, string> = {
+  // ===== Images =====
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.heic': 'image/heic',
+  '.heif': 'image/heif',
+  '.avif': 'image/avif',
+
+  // ===== Audio =====
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.flac': 'audio/flac',
+  '.aac': 'audio/aac',
+  '.ogg': 'audio/ogg',
+  '.m4a': 'audio/mp4',
+  '.weba': 'audio/webm',
+  '.webm': 'video/webm', // Note: .webm mapped to video; audio/webm uses .weba
+  '.aiff': 'audio/x-aiff',
+  '.aif': 'audio/x-aiff',
+  '.opus': 'audio/opus',
+  '.amr': 'audio/amr',
+  '.mid': 'audio/midi',
+  '.midi': 'audio/midi',
+
+  // ===== Video =====
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  // .webm already mapped above to video/webm
+  '.mov': 'video/quicktime',
+  '.avi': 'video/x-msvideo',
+  '.mpeg': 'video/mpeg',
+  '.mpg': 'video/mpeg',
+  '.mkv': 'video/x-matroska',
+  '.flv': 'video/x-flv',
+  '.3gp': 'video/3gpp',
+  '.3g2': 'video/3gpp2',
+  '.wmv': 'video/x-ms-wmv',
+
+  // ===== Documents =====
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.rtf': 'application/rtf',
+  '.epub': 'application/epub+zip',
+  '.odt': 'application/vnd.oasis.opendocument.text',
+  '.ods': 'application/vnd.oasis.opendocument.spreadsheet',
+  '.odp': 'application/vnd.oasis.opendocument.presentation',
+
+  // ===== Text / Code =====
+  '.txt': 'text/plain',
+  '.text': 'text/plain',
+  '.log': 'text/plain',
+  '.out': 'text/plain',
+  '.env': 'text/plain',
+  '.gitignore': 'text/plain',
+  '.gitattributes': 'text/plain',
+  '.dockerignore': 'text/plain',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.csv': 'text/csv',
+  '.tsv': 'text/csv',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.mdown': 'text/markdown',
+  '.mkd': 'text/markdown',
+  '.xml': 'text/xml',
+  '.py': 'text/x-python',
+  '.pyw': 'text/x-python',
+  '.pyx': 'text/x-python',
+  '.pyi': 'text/x-python',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.cjs': 'text/javascript',
+  '.jsx': 'text/javascript',
+  '.ts': 'text/x-typescript',
+  '.mts': 'text/x-typescript',
+  '.cts': 'text/x-typescript',
+  '.tsx': 'text/x-typescript',
+  '.c': 'text/x-c',
+  '.h': 'text/x-c',
+  '.cpp': 'text/x-c++src',
+  '.cxx': 'text/x-c++src',
+  '.cc': 'text/x-c++src',
+  '.hpp': 'text/x-c++src',
+  '.java': 'text/x-java',
+  '.go': 'text/x-go',
+  '.rs': 'text/x-rust',
+  '.rb': 'text/x-ruby',
+  '.rake': 'text/x-ruby',
+  '.gemspec': 'text/x-ruby',
+  '.php': 'text/x-php',
+  '.phtml': 'text/x-php',
+  '.swift': 'text/x-swift',
+  '.kt': 'text/x-kotlin',
+  '.kts': 'text/x-kotlin',
+  '.scala': 'text/x-scala',
+  '.pl': 'text/x-perl',
+  '.pm': 'text/x-perl',
+  '.t': 'text/x-perl',
+  '.pod': 'text/x-perl',
+  '.lua': 'text/x-lua',
+  '.erl': 'text/x-erlang',
+  '.hrl': 'text/x-erlang',
+  '.hs': 'text/x-haskell',
+  '.lhs': 'text/x-haskell',
+  '.clj': 'text/x-clojure',
+  '.cljs': 'text/x-clojure',
+  '.cljc': 'text/x-clojure',
+  '.ex': 'text/x-elixir',
+  '.exs': 'text/x-elixir',
+  '.sh': 'text/x-shellscript',
+  '.bash': 'text/x-shellscript',
+  '.zsh': 'text/x-shellscript',
+  '.fish': 'text/x-shellscript',
+  '.sql': 'text/x-sql',
+  '.diff': 'text/x-diff',
+  '.patch': 'text/x-diff',
+  '.yaml': 'text/x-yaml',
+  '.yml': 'text/x-yaml',
+  '.toml': 'text/x-toml',
+  '.ini': 'text/plain',
+  '.cfg': 'text/plain',
+  '.conf': 'text/plain',
+  '.properties': 'text/plain',
+  '.tcl': 'text/x-tcl',
+  '.bib': 'text/x-bibtex',
+  '.r': 'text/plain',
+  '.rmd': 'text/plain',
+  '.jl': 'text/plain',
+  '.dart': 'text/plain',
+  '.nim': 'text/plain',
+  '.zig': 'text/plain',
+  '.v': 'text/plain',
+  '.vhd': 'text/plain',
+  '.vhdl': 'text/plain',
+  '.asm': 'text/plain',
+  '.s': 'text/plain',
+  '.f': 'text/plain',
+  '.f90': 'text/plain',
+  '.f95': 'text/plain',
+  '.pas': 'text/plain',
+  '.d': 'text/plain',
+  '.ada': 'text/plain',
+  '.adb': 'text/plain',
+  '.ads': 'text/plain',
+  '.lisp': 'text/plain',
+  '.lsp': 'text/plain',
+  '.cl': 'text/plain',
+  '.scm': 'text/plain',
+  '.rkt': 'text/plain',
+  '.groovy': 'text/plain',
+  '.gvy': 'text/plain',
+  '.coffee': 'text/plain',
+  '.elm': 'text/plain',
+  '.sol': 'text/plain',
+  '.rst': 'text/plain',
+  '.asciidoc': 'text/plain',
+  '.adoc': 'text/plain',
+  '.tex': 'text/plain',
+  '.latex': 'text/plain',
+  '.nix': 'text/plain',
+  '.dockerfile': 'text/plain',
+  '.bat': 'text/plain',
+  '.cmd': 'text/plain',
+  '.ps1': 'text/plain',
+  '.psm1': 'text/plain',
+  '.vue': 'text/plain',
+  '.svelte': 'text/plain',
+  '.astro': 'text/plain',
+  '.scss': 'text/plain',
+  '.sass': 'text/plain',
+  '.less': 'text/plain',
+  '.styl': 'text/plain',
+
+  // ===== Structured Data =====
+  '.json': 'application/json',
+  '.jsonc': 'application/json',
+  '.json5': 'application/json',
+  '.jsonld': 'application/ld+json',
+  '.graphql': 'application/graphql',
+  '.gql': 'application/graphql',
+
+  // ===== Archives =====
+  '.zip': 'application/zip',
+  '.gz': 'application/gzip',
+  '.tar': 'application/x-tar',
+
+  // ===== Fonts =====
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+
+  // ===== Other =====
+  '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream',
+};
+
+/** Lazily-built reverse map from MIME type → extensions. */
+let _mimeToExtensions: Map<string, string[]> | undefined;
+
+/**
+ * Returns a Map from MIME type to an array of extensions that map to it.
+ * The result is cached — repeated calls return the same Map instance.
+ */
+export function getMimeToExtensionsMap(): Map<string, string[]> {
+  if (_mimeToExtensions) return _mimeToExtensions;
+
+  _mimeToExtensions = new Map<string, string[]>();
+  for (const [ext, mime] of Object.entries(COMPREHENSIVE_EXTENSION_MAP)) {
+    const existing = _mimeToExtensions.get(mime);
+    if (existing) {
+      existing.push(ext);
+    } else {
+      _mimeToExtensions.set(mime, [ext]);
+    }
+  }
+
+  return _mimeToExtensions;
+}

--- a/src/support-registry/extensionMap.ts
+++ b/src/support-registry/extensionMap.ts
@@ -86,7 +86,7 @@ export const COMPREHENSIVE_EXTENSION_MAP: Record<string, string> = {
   '.htm': 'text/html',
   '.css': 'text/css',
   '.csv': 'text/csv',
-  '.tsv': 'text/csv',
+  '.tsv': 'text/tab-separated-values',
   '.md': 'text/markdown',
   '.markdown': 'text/markdown',
   '.mdown': 'text/markdown',

--- a/src/support-registry/extensionMap.ts
+++ b/src/support-registry/extensionMap.ts
@@ -224,25 +224,33 @@ export const COMPREHENSIVE_EXTENSION_MAP: Record<string, string> = {
   '.bin': 'application/octet-stream',
 };
 
-/** Lazily-built reverse map from MIME type → extensions. */
-let _mimeToExtensions: Map<string, string[]> | undefined;
+/** Lazily-built reverse map from MIME type → extensions (immutable). */
+let _mimeToExtensions: ReadonlyMap<string, readonly string[]> | undefined;
 
 /**
- * Returns a Map from MIME type to an array of extensions that map to it.
- * The result is cached — repeated calls return the same Map instance.
+ * Returns a ReadonlyMap from MIME type to a frozen array of extensions.
+ * The result is cached — repeated calls return the same instance.
+ * Both the map and its arrays are immutable to prevent cache corruption.
  */
-export function getMimeToExtensionsMap(): Map<string, string[]> {
+export function getMimeToExtensionsMap(): ReadonlyMap<string, readonly string[]> {
   if (_mimeToExtensions) return _mimeToExtensions;
 
-  _mimeToExtensions = new Map<string, string[]>();
+  const building = new Map<string, string[]>();
   for (const [ext, mime] of Object.entries(COMPREHENSIVE_EXTENSION_MAP)) {
-    const existing = _mimeToExtensions.get(mime);
+    const existing = building.get(mime);
     if (existing) {
       existing.push(ext);
     } else {
-      _mimeToExtensions.set(mime, [ext]);
+      building.set(mime, [ext]);
     }
   }
 
+  // Freeze each array to prevent mutation
+  const frozen = new Map<string, readonly string[]>();
+  for (const [mime, exts] of building) {
+    frozen.set(mime, Object.freeze(exts));
+  }
+
+  _mimeToExtensions = frozen;
   return _mimeToExtensions;
 }

--- a/src/support-registry/index.ts
+++ b/src/support-registry/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './extensionMap.js';
+export * from './supportRegistry.js';

--- a/src/support-registry/supportRegistry.test.ts
+++ b/src/support-registry/supportRegistry.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  GEMINI_SUPPORT_MATRIX,
+  INLINE_SIZE_LIMIT,
+  FILE_API_SIZE_LIMIT,
+  isInlineSupported,
+  getMimeSupport,
+  getSupportedMimes,
+  mimeForExtension,
+  classifyExtension,
+  getModelCapabilities,
+} from './supportRegistry.js';
+
+describe('GEMINI_SUPPORT_MATRIX', () => {
+  it('should be an object', () => {
+    expect(typeof GEMINI_SUPPORT_MATRIX).toBe('object');
+    expect(GEMINI_SUPPORT_MATRIX).not.toBeNull();
+  });
+
+  it('should have valid structure when non-empty', () => {
+    const entries = Object.entries(GEMINI_SUPPORT_MATRIX);
+    if (entries.length === 0) return; // Stub matrix is empty - skip structural checks
+
+    for (const [mimeType, entry] of entries) {
+      expect(mimeType).toContain('/');
+      expect(entry.category).toBeDefined();
+      expect(entry.extension).toBeDefined();
+      expect(entry.description).toBeDefined();
+      expect(typeof entry.models).toBe('object');
+    }
+  });
+});
+
+describe('size limits', () => {
+  it('should have correct inline size limit (20MB)', () => {
+    expect(INLINE_SIZE_LIMIT).toBe(20 * 1024 * 1024);
+  });
+
+  it('should have correct File API size limit (2GB)', () => {
+    expect(FILE_API_SIZE_LIMIT).toBe(2 * 1024 * 1024 * 1024);
+  });
+});
+
+describe('isInlineSupported', () => {
+  it('should return false for unknown MIME types', () => {
+    expect(isInlineSupported('application/x-totally-made-up')).toBe(false);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isInlineSupported('')).toBe(false);
+  });
+
+  // Conditional tests that only run when matrix has data
+  it('should return a boolean for text/plain', () => {
+    const result = isInlineSupported('text/plain');
+    expect(typeof result).toBe('boolean');
+  });
+});
+
+describe('getMimeSupport', () => {
+  it('should return undefined for unknown MIME types', () => {
+    expect(getMimeSupport('application/x-totally-made-up')).toBeUndefined();
+  });
+
+  it('should return entry with correct shape when found', () => {
+    const entries = Object.keys(GEMINI_SUPPORT_MATRIX);
+    if (entries.length === 0) return;
+
+    const support = getMimeSupport(entries[0]);
+    expect(support).toBeDefined();
+    expect(support!.mimeType).toBe(entries[0]);
+    expect(Array.isArray(support!.extensions)).toBe(true);
+    expect(support!.extensions.length).toBeGreaterThan(0);
+    expect(typeof support!.category).toBe('string');
+    expect(Array.isArray(support!.supportedModels)).toBe(true);
+    expect(typeof support!.requiresFileApi).toBe('boolean');
+    expect(support!.inlineSizeLimit).toBe(INLINE_SIZE_LIMIT);
+  });
+});
+
+describe('getSupportedMimes', () => {
+  it('should return an array', () => {
+    const result = getSupportedMimes('image');
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('should return entries with correct category', () => {
+    const result = getSupportedMimes('text');
+    for (const entry of result) {
+      expect(entry.category).toBe('text');
+    }
+  });
+
+  it('should return empty array for category with no data', () => {
+    // If matrix is empty, all categories return empty
+    const entries = Object.keys(GEMINI_SUPPORT_MATRIX);
+    if (entries.length === 0) {
+      expect(getSupportedMimes('image')).toEqual([]);
+    }
+  });
+});
+
+describe('mimeForExtension', () => {
+  it('should handle extension with dot', () => {
+    expect(mimeForExtension('.png')).toBe('image/png');
+  });
+
+  it('should handle extension without dot', () => {
+    expect(mimeForExtension('png')).toBe('image/png');
+  });
+
+  it('should be case-insensitive', () => {
+    expect(mimeForExtension('.PNG')).toBe('image/png');
+    expect(mimeForExtension('PDF')).toBe('application/pdf');
+    expect(mimeForExtension('.Mp3')).toBe('audio/mpeg');
+  });
+
+  it('should return undefined for unknown extensions', () => {
+    expect(mimeForExtension('.xyz123')).toBeUndefined();
+    expect(mimeForExtension('unknown')).toBeUndefined();
+  });
+
+  it('should handle common types correctly', () => {
+    expect(mimeForExtension('.pdf')).toBe('application/pdf');
+    expect(mimeForExtension('.jpg')).toBe('image/jpeg');
+    expect(mimeForExtension('.mp4')).toBe('video/mp4');
+    expect(mimeForExtension('.txt')).toBe('text/plain');
+    expect(mimeForExtension('.json')).toBe('application/json');
+  });
+});
+
+describe('classifyExtension', () => {
+  it('should return undefined for unknown extensions', () => {
+    expect(classifyExtension('.xyz123unknown')).toBeUndefined();
+  });
+
+  it('should classify image extensions', () => {
+    const result = classifyExtension('.png');
+    expect(result).toBeDefined();
+    expect(result!.category).toBe('image');
+    expect(result!.mimeType).toBe('image/png');
+  });
+
+  it('should classify audio extensions', () => {
+    const result = classifyExtension('.mp3');
+    expect(result).toBeDefined();
+    expect(result!.category).toBe('audio');
+    expect(result!.mimeType).toBe('audio/mpeg');
+  });
+
+  it('should classify video extensions', () => {
+    const result = classifyExtension('.mp4');
+    expect(result).toBeDefined();
+    expect(result!.category).toBe('video');
+    expect(result!.mimeType).toBe('video/mp4');
+  });
+
+  it('should classify document extensions', () => {
+    const result = classifyExtension('.pdf');
+    expect(result).toBeDefined();
+    expect(result!.category).toBe('document');
+    expect(result!.mimeType).toBe('application/pdf');
+  });
+
+  it('should classify text extensions', () => {
+    const result = classifyExtension('.txt');
+    expect(result).toBeDefined();
+    expect(result!.category).toBe('text');
+    expect(result!.mimeType).toBe('text/plain');
+  });
+
+  it('should handle extension without dot', () => {
+    const result = classifyExtension('png');
+    expect(result).toBeDefined();
+    expect(result!.mimeType).toBe('image/png');
+  });
+});
+
+describe('getModelCapabilities', () => {
+  it('should return defaults for unknown models', () => {
+    const caps = getModelCapabilities('totally-unknown-model');
+    expect(caps.supportsImages).toBe(false);
+    expect(caps.supportsAudio).toBe(false);
+    expect(caps.supportsVideo).toBe(false);
+    expect(caps.supportsPdf).toBe(false);
+    expect(caps.inlineSizeLimit).toBe(INLINE_SIZE_LIMIT);
+  });
+
+  it('should return correct inlineSizeLimit', () => {
+    const caps = getModelCapabilities('any-model');
+    expect(caps.inlineSizeLimit).toBe(20 * 1024 * 1024);
+  });
+
+  it('should return booleans for all capability flags', () => {
+    const caps = getModelCapabilities('test-model');
+    expect(typeof caps.supportsImages).toBe('boolean');
+    expect(typeof caps.supportsAudio).toBe('boolean');
+    expect(typeof caps.supportsVideo).toBe('boolean');
+    expect(typeof caps.supportsPdf).toBe('boolean');
+  });
+});

--- a/src/support-registry/supportRegistry.ts
+++ b/src/support-registry/supportRegistry.ts
@@ -1,0 +1,214 @@
+/**
+ * Gemini MIME Type Support Registry.
+ *
+ * Provides query functions for checking which MIME types the Gemini API
+ * supports, based on data from the generated support matrix.
+ */
+
+import matrixData from '../generated/gemini-support-matrix.json' with { type: 'json' };
+import { COMPREHENSIVE_EXTENSION_MAP, getMimeToExtensionsMap } from './extensionMap.js';
+import type {
+  MimeCategory,
+  MimeSupportMatrixEntry,
+  MimeSupportEntry,
+  ModelCapabilities,
+} from './types.js';
+
+/** Hardcoded inline size limit from Gemini docs: 20 MB. */
+export const INLINE_SIZE_LIMIT = 20 * 1024 * 1024;
+
+/** Hardcoded File API size limit from Gemini docs: 2 GB. */
+export const FILE_API_SIZE_LIMIT = 2 * 1024 * 1024 * 1024;
+
+/** The raw generated support matrix. */
+export const GEMINI_SUPPORT_MATRIX: Record<string, MimeSupportMatrixEntry> =
+  matrixData as Record<string, MimeSupportMatrixEntry>;
+
+/** The 5 consumer categories. Internal probe categories map to these. */
+const CATEGORY_MAP: Record<string, MimeCategory> = {
+  image: 'image',
+  audio: 'audio',
+  video: 'video',
+  document: 'document',
+  text: 'text',
+  // Probe-internal categories → consumer categories
+  data: 'text',
+  archive: 'document',
+  font: 'document',
+  application: 'text',
+};
+
+function toConsumerCategory(raw: string): MimeCategory {
+  return CATEGORY_MAP[raw] ?? 'text';
+}
+
+/**
+ * Check if a MIME type is supported for inline base64 upload.
+ *
+ * @param mimeType - The MIME type to check.
+ * @param model - Optional model name. If omitted, returns true if any model supports it.
+ */
+export function isInlineSupported(mimeType: string, model?: string): boolean {
+  const entry = GEMINI_SUPPORT_MATRIX[mimeType];
+  if (!entry) return false;
+
+  if (model) {
+    return entry.models[model]?.inline === true;
+  }
+
+  return Object.values(entry.models).some(m => m.inline);
+}
+
+/**
+ * Get full support info for a MIME type.
+ *
+ * @param mimeType - The MIME type to look up.
+ * @returns Support entry or undefined if not in the matrix.
+ */
+export function getMimeSupport(mimeType: string): MimeSupportEntry | undefined {
+  const entry = GEMINI_SUPPORT_MATRIX[mimeType];
+  if (!entry) return undefined;
+
+  const reverseMap = getMimeToExtensionsMap();
+  const extensions = reverseMap.get(mimeType) ?? [entry.extension];
+
+  const supportedModels = Object.entries(entry.models)
+    .filter(([, m]) => m.inline || m.fileApi)
+    .map(([name]) => name);
+
+  const requiresFileApi =
+    supportedModels.length > 0 &&
+    Object.values(entry.models).some(m => m.fileApi && !m.inline);
+
+  return {
+    mimeType,
+    extensions,
+    category: toConsumerCategory(entry.category),
+    supportedModels,
+    requiresFileApi,
+    inlineSizeLimit: INLINE_SIZE_LIMIT,
+  };
+}
+
+/**
+ * Get all supported MIME types for a category.
+ *
+ * @param category - One of the 5 consumer categories.
+ * @param model - Optional model filter.
+ */
+export function getSupportedMimes(
+  category: MimeCategory,
+  model?: string,
+): MimeSupportEntry[] {
+  const results: MimeSupportEntry[] = [];
+
+  for (const [mimeType, entry] of Object.entries(GEMINI_SUPPORT_MATRIX)) {
+    if (toConsumerCategory(entry.category) !== category) continue;
+
+    // Check if any (or the specific) model supports it
+    const hasSupport = model
+      ? entry.models[model]?.inline || entry.models[model]?.fileApi
+      : Object.values(entry.models).some(m => m.inline || m.fileApi);
+
+    if (!hasSupport) continue;
+
+    const support = getMimeSupport(mimeType);
+    if (support) results.push(support);
+  }
+
+  return results;
+}
+
+/**
+ * Look up the canonical MIME type for a file extension.
+ *
+ * @param extension - File extension (with or without leading dot, case-insensitive).
+ * @returns The MIME type, or undefined if not recognized.
+ */
+export function mimeForExtension(extension: string): string | undefined {
+  const normalized = extension.toLowerCase();
+  const withDot = normalized.startsWith('.') ? normalized : `.${normalized}`;
+  return COMPREHENSIVE_EXTENSION_MAP[withDot];
+}
+
+/** Well-known application/* MIME types that are documents. */
+const DOCUMENT_APPLICATION_MIMES = new Set([
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/rtf',
+  'application/epub+zip',
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.oasis.opendocument.presentation',
+]);
+
+function guessCategoryFromMime(mimeType: string): MimeCategory {
+  if (DOCUMENT_APPLICATION_MIMES.has(mimeType)) return 'document';
+  const prefix = mimeType.split('/')[0];
+  return CATEGORY_MAP[prefix] ?? 'text';
+}
+
+/**
+ * Classify a file extension: determine its category, MIME type, and support status.
+ *
+ * @param extension - File extension (with or without leading dot, case-insensitive).
+ * @param model - Optional model to check support against.
+ */
+export function classifyExtension(
+  extension: string,
+  model?: string,
+): { category: MimeCategory; mimeType: string; supported: boolean } | undefined {
+  const mimeType = mimeForExtension(extension);
+  if (!mimeType) return undefined;
+
+  const matrixEntry = GEMINI_SUPPORT_MATRIX[mimeType];
+  if (!matrixEntry) {
+    // Known extension but not in matrix — guess category from MIME type
+    const category = guessCategoryFromMime(mimeType);
+    return { category, mimeType, supported: false };
+  }
+
+  const category = toConsumerCategory(matrixEntry.category);
+  const supported = model
+    ? (matrixEntry.models[model]?.inline || matrixEntry.models[model]?.fileApi) === true
+    : Object.values(matrixEntry.models).some(m => m.inline || m.fileApi);
+
+  return { category, mimeType, supported };
+}
+
+/**
+ * Get a summary of what a model supports.
+ *
+ * @param model - The model name.
+ */
+export function getModelCapabilities(model: string): ModelCapabilities {
+  let supportsImages = false;
+  let supportsAudio = false;
+  let supportsVideo = false;
+  let supportsPdf = false;
+
+  for (const [mimeType, entry] of Object.entries(GEMINI_SUPPORT_MATRIX)) {
+    const modelSupport = entry.models[model];
+    if (!modelSupport) continue;
+    if (!modelSupport.inline && !modelSupport.fileApi) continue;
+
+    const cat = toConsumerCategory(entry.category);
+    if (cat === 'image') supportsImages = true;
+    if (cat === 'audio') supportsAudio = true;
+    if (cat === 'video') supportsVideo = true;
+    if (mimeType === 'application/pdf') supportsPdf = true;
+  }
+
+  return {
+    supportsImages,
+    supportsAudio,
+    supportsVideo,
+    supportsPdf,
+    inlineSizeLimit: INLINE_SIZE_LIMIT,
+  };
+}

--- a/src/support-registry/supportRegistry.ts
+++ b/src/support-registry/supportRegistry.ts
@@ -70,7 +70,7 @@ export function getMimeSupport(mimeType: string): MimeSupportEntry | undefined {
   if (!entry) return undefined;
 
   const reverseMap = getMimeToExtensionsMap();
-  const extensions = reverseMap.get(mimeType) ?? [entry.extension];
+  const extensions = [...(reverseMap.get(mimeType) ?? [entry.extension])];
 
   const supportedModels = Object.entries(entry.models)
     .filter(([, m]) => m.inline || m.fileApi)

--- a/src/support-registry/types.ts
+++ b/src/support-registry/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Types for the Gemini MIME Type Support Registry.
+ */
+
+/** The 5 content categories consumers care about. */
+export type MimeCategory = 'image' | 'audio' | 'video' | 'document' | 'text';
+
+/** Error classification for probe failures. */
+export type ErrorClass =
+  | 'mime_rejected'
+  | 'content_invalid'
+  | 'rate_limited'
+  | 'unknown';
+
+/** Per-model support status from probe results. */
+export interface ModelSupport {
+  /** Whether inline base64 upload succeeded. */
+  inline: boolean;
+  /** Whether File API upload succeeded. */
+  fileApi: boolean;
+  /** If inline failed, the classified error. */
+  inlineErrorClass?: ErrorClass;
+  /** If File API failed, the classified error. */
+  fileApiErrorClass?: ErrorClass;
+}
+
+/** Shape of each entry in the generated support matrix JSON. */
+export interface MimeSupportMatrixEntry {
+  /** MIME type category (may include probe-internal categories like 'data', 'archive'). */
+  category: string;
+  /** File extension (with leading dot). */
+  extension: string;
+  /** Human-readable description. */
+  description: string;
+  /** Per-model support results keyed by model name. */
+  models: Record<string, ModelSupport>;
+}
+
+/** Consumer-facing support info for a MIME type. */
+export interface MimeSupportEntry {
+  /** The MIME type string. */
+  mimeType: string;
+  /** Mapped file extensions (with leading dots). */
+  extensions: string[];
+  /** Category (mapped to the 5 consumer categories). */
+  category: MimeCategory;
+  /** Models that support this MIME type (inline or file API). */
+  supportedModels: string[];
+  /** Whether at least one model requires File API (inline not supported). */
+  requiresFileApi: boolean;
+  /** Inline size limit in bytes (hardcoded from docs). */
+  inlineSizeLimit: number;
+}
+
+/** Per-model capability summary. */
+export interface ModelCapabilities {
+  supportsImages: boolean;
+  supportsAudio: boolean;
+  supportsVideo: boolean;
+  supportsPdf: boolean;
+  inlineSizeLimit: number;
+}


### PR DESCRIPTION
## Summary
- Add a new `support-registry` module that provides a queryable API for checking which MIME types the Gemini API supports for inline base64 vs File API uploads
- Refactor the probe script with error classification, rate limiting, multi-model support (`--model` flag), and automated matrix JSON generation
- Add a comprehensive extension-to-MIME mapping (190+ entries) consolidating data from file-search, audio-transcription, and the probe catalog
- Add a GitHub Actions workflow for weekly automated probing with auto-PR creation
- Include initial probe data for `gemini-3.0-flash-preview` (87 MIME types tested)

### New consumer API
```typescript
import {
  isInlineSupported,
  getMimeSupport,
  getSupportedMimes,
  mimeForExtension,
  classifyExtension,
  getModelCapabilities,
  GEMINI_SUPPORT_MATRIX,
} from '@allenhutchison/gemini-utils';
```

### Backward compatibility
No changes to existing `file-search/mimeTypes.ts` or `audio-transcription/audioMimeTypes.ts` — the registry is a purely additive module.

## Test plan
- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint errors
- [x] `npm test` — all 221 tests pass (10 existing suites + 2 new)
- [x] `npm run build` — builds successfully, `dist/generated/` contains the matrix JSON
- [x] Probe script runs end-to-end against real API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a MIME type support registry and probe CLI that generate a per-model inline/File-API support matrix and reports.
  * Exposed the support-registry via the package's main exports for easy consumer access.

* **Chores**
  * Added an automated weekly probe workflow and an npm script to run the probe; probe report files are now ignored.

* **Tests**
  * Added comprehensive tests for extension mappings and support-registry utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->