### PR TITLE
ci: auto-publish on release-please releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref (tag/branch/sha) to publish from, e.g. v0.6.0'
+        description: 'Release tag to publish from, e.g. v0.6.0'
         required: true
 
 jobs:
@@ -15,6 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate manual ref is a version tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          REF="${{ github.event.inputs.ref }}"
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
+            echo "::error::Input ref must be a version tag (e.g. v1.2.3); got '$REF'."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (tag/branch/sha) to publish from, e.g. v0.6.0'
+        required: true
 
 jobs:
   publish:
@@ -12,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout released tag
         uses: actions/checkout@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,43 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

When PR #35 (the release-please-generated v0.6.0 release PR) merged, the `v0.6.0` tag was created but `publish.yml` did not fire — so 0.6.0 was tagged + GitHub-released but never published to npm.

**Root cause**: GitHub Actions does not trigger workflows from events fired by the default `GITHUB_TOKEN`. Release-please pushed the tag using `GITHUB_TOKEN`, so `publish.yml`'s `on: push: tags: 'v*'` trigger silently no-op'd. ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow))

## What

### `.github/workflows/release-please.yml` — systemic fix

Adds a `publish` job that runs in the same workflow as release-please, gated on the `release_created` output. Checks out the freshly created tag and runs lint/test/build/publish. Because both jobs are in the same workflow, there's no cross-workflow trigger problem to work around.

### `.github/workflows/publish.yml` — recovery hatch

Adds `workflow_dispatch` with a `ref` input so any past tag can be manually published. The `push: tags: 'v*'` trigger is preserved for hand-pushed tags. Used immediately to publish `v0.6.0` after this PR lands.

## After merge — recovery steps for v0.6.0

\`\`\`bash
gh workflow run publish.yml --ref main -f ref=v0.6.0
gh run watch
\`\`\`

## Test plan
- [ ] Merge this PR
- [ ] Run \`gh workflow run publish.yml --ref main -f ref=v0.6.0\`
- [ ] Confirm \`@allenhutchison/gemini-utils@0.6.0\` appears on npmjs.org
- [ ] Future release-please PRs auto-publish (no manual step required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Manual publish now accepts a user-supplied ref with validation to ensure proper version-tag format, enabling controlled manual releases from specific refs.
  * Automated publishing enhanced: when a release is created, the pipeline runs a publish job that checks out the release tag, builds, and publishes the package to npm automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->