### PR TITLE
ci: switch to npm Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,16 @@ on:
       ref:
         description: 'Release tag to publish from, e.g. v0.6.0'
         required: true
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Release tag to publish from'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -18,7 +28,7 @@ jobs:
       - name: Validate manual ref is a version tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          REF="${{ github.event.inputs.ref }}"
+          REF="${{ inputs.ref }}"
           if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
             echo "::error::Input ref must be a version tag (e.g. v1.2.3); got '$REF'."
             exit 1
@@ -27,14 +37,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to >=11.5.1 (required for Trusted Publishers)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -49,6 +62,4 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,35 +23,9 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - name: Checkout released tag
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      id-token: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Why

The v0.6.0 publish failed with `ENEEDAUTH` — there's no `NPM_TOKEN` secret. Per [npm's docs](https://docs.npmjs.com/trusted-publishers), tokens are no longer recommended; the modern path is **Trusted Publishers** (OIDC), which:

- Eliminates long-lived secrets to manage / rotate
- Adds free signed provenance attestations
- Auto-enrolls publishes in npm's "verified" badge

## Changes

### `publish.yml` — single source of truth for publishing
- Adds `workflow_call` trigger so `release-please.yml` can reuse it
- Adds `permissions: id-token: write` (required for OIDC)
- Bumps Node to 22 + upgrades npm to ≥11.5.1 (Trusted Publisher minimum)
- Drops `NODE_AUTH_TOKEN`; OIDC handles auth automatically
- Adds `--provenance` flag for signed attestations
- Unifies `${{ github.event.inputs.ref }}` → `${{ inputs.ref }}` so the same expression works for both `workflow_dispatch` and `workflow_call`

### `release-please.yml` — calls publish.yml as a reusable workflow
Replaces the inlined publish steps (~25 lines) with a 4-line `uses: ./.github/workflows/publish.yml` call. Now there's exactly one workflow that runs `npm publish` — so a single Trusted Publisher entry on npm covers both auto-on-release and manual recovery publishes.

## Required manual step (you, after merge)

1. Visit https://www.npmjs.com/package/@allenhutchison/gemini-utils/access (or Settings → Publishing access)
2. Add a Trusted Publisher with:
   - **Provider**: GitHub Actions
   - **Organization or user**: `allenhutchison`
   - **Repository**: `gemini-utils`
   - **Workflow filename**: `publish.yml`
   - **Environment name**: leave empty
3. (Recommended) Set "Require two-factor authentication and disallow tokens" once OIDC is working — closes the credential surface area entirely.

## After the manual step
Run `gh workflow run publish.yml --ref main -f ref=v0.6.0` to publish v0.6.0 via OIDC.

## Test plan
- [ ] Configure Trusted Publisher on npmjs.com (manual step above)
- [ ] Merge this PR
- [ ] Trigger publish workflow for v0.6.0
- [ ] Verify `0.6.0` appears on npm with provenance badge
- [ ] On the next release-please-driven release, confirm auto-publish succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package publishing now includes provenance support for improved security and integrity verification.

* **Chores**
  * Updated build environment to Node.js 22.
  * Streamlined publishing workflow architecture for improved maintainability.
  * Enhanced dependency management with explicit npm upgrade step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->