### PR TITLE
ci(publish): use Node 24 for built-in npm 11.5.1+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm to >=11.5.1 (required for Trusted Publishers)
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why
The v0.6.0 publish (after Trusted Publishers landed in #37) failed with:
\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`
during \`npm install -g npm@latest\`. This is a [known self-upgrade bug](https://github.com/npm/cli/issues/4860): the running npm process loses access to its own modules mid-upgrade because the install overwrites them.

## Fix
Drop the manual upgrade step and use Node 24, which ships with npm 11.5.x out of the box — satisfying the Trusted Publisher minimum (npm ≥ 11.5.1) without the fragile self-upgrade.

## Test plan
- [ ] Merge
- [ ] Re-trigger publish for v0.6.0: \`gh workflow run publish.yml --ref main -f ref=v0.6.0\`
- [ ] Confirm 0.6.0 appears on npm with provenance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version for the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->