### PR TITLE
feat!: upgrade @google/genai to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.0](https://github.com/allenhutchison/gemini-utils/compare/v0.6.0...v0.7.0) (2026-05-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* require `@google/genai` >= 2.0.0. The Interactions API response shape changed in v2: `Interaction.outputs` was removed; output content now lives in `Interaction.steps[]` (filtered to `ModelOutputStep.content[]`). Use the new `extractOutputs(interaction)` helper from `@allenhutchison/gemini-utils/research` to read text/image/audio content out of an interaction.
+
+
+### Features
+
+* upgrade `@google/genai` peer dependency from 1.x to 2.x
+* add `extractOutputs(interaction)` helper that flattens `interaction.steps` into the v1-equivalent `InteractionOutput[]`
+* add `'incomplete'` to `InteractionStatus` and `TERMINAL_STATUSES` (introduced by SDK v2)
+
+
+### Bug Fixes
+
+* drop now-unnecessary `interactions.create` type-assertion workaround in `FileSearchManager.queryStore` (v2 types this surface natively)
+
 ## [0.6.0](https://github.com/allenhutchison/gemini-utils/compare/v0.5.0...v0.6.0) (2026-05-03)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@allenhutchison/gemini-utils",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@allenhutchison/gemini-utils",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@google/genai": "^1.34.0",
+        "@google/genai": "^2.1.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.0.9",
         "eslint": "^10.0.0",
@@ -32,7 +32,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@google/genai": ">=1.29.0"
+        "@google/genai": ">=2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.1.0.tgz",
+      "integrity": "sha512-2tF/P5LMkiV31slQpTA92EqP7SRHB8VM1IXWdtC9jWzpp8J5j4TakywSqpB/R0K1aPLlpMt3PgB2O1c/+wJPXQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@allenhutchison/gemini-utils",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared utilities for Google Gemini AI projects - file upload, MIME validation, operation tracking, and deep research",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/allenhutchison/gemini-utils#readme",
   "peerDependencies": {
-    "@google/genai": ">=1.29.0"
+    "@google/genai": ">=2.0.0"
   },
   "bin": {
     "gemini-utils": "./dist/cli/main.js"
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@google/genai": "^1.34.0",
+    "@google/genai": "^2.1.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.9",
     "eslint": "^10.0.0",

--- a/src/audio-transcription/TranscriptionManager.test.ts
+++ b/src/audio-transcription/TranscriptionManager.test.ts
@@ -30,7 +30,12 @@ describe('TranscriptionManager', () => {
       const mockInteraction = {
         id: 'interaction-123',
         status: 'completed',
-        outputs: [{ type: 'text', text: 'Transcribed text' }],
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'text', text: 'Transcribed text' }],
+          },
+        ],
       };
       mockClient.interactions.get.mockResolvedValue(mockInteraction);
 

--- a/src/audio-transcription/TranscriptionManager.ts
+++ b/src/audio-transcription/TranscriptionManager.ts
@@ -2,7 +2,7 @@
  * TranscriptionManager - Manages audio transcription interactions with Google's Gemini API.
  * Provides methods to transcribe audio files using the Interactions API.
  */
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, Interactions } from '@google/genai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -41,20 +41,7 @@ interface GenerateContentResponse {
   }>;
 }
 
-/**
- * Interaction response from the Gemini API (for polling uploaded files).
- */
-interface InteractionResponse {
-  id?: string;
-  status?: string;
-  outputs?: Array<{
-    type?: string;
-    text?: string;
-  }>;
-  error?: {
-    message?: string;
-  };
-}
+type InteractionResponse = Interactions.Interaction;
 
 /**
  * File metadata from the Gemini Files API.

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -4,6 +4,7 @@
 
 import { Command } from 'commander';
 import { FileSearchManager } from '../../file-search/index.js';
+import { extractOutputs } from '../../research/index.js';
 import { output } from '../utils/output.js';
 import { handleError } from '../utils/errors.js';
 
@@ -35,7 +36,7 @@ export function registerQueryCommand(program: Command): void {
 
         output(outputContext, interaction, () => {
           // Extract text content and citations from outputs
-          const outputs = interaction.outputs ?? [];
+          const outputs = extractOutputs(interaction);
           const textParts: string[] = [];
           const citations = new Set<string>();
 

--- a/src/cli/commands/research.ts
+++ b/src/cli/commands/research.ts
@@ -160,8 +160,9 @@ export function registerResearchCommands(program: Command): void {
         const completed = await researcher.poll(interaction.id);
         const completedOutputs = extractOutputs(completed);
 
-        // Generate report if output file specified
-        if (options.output && completedOutputs.length) {
+        // Generate report if output file specified (even if empty,
+        // so scripted callers always see the file they asked for).
+        if (options.output) {
           await writeReport(options.output, completedOutputs, outputContext);
         }
 
@@ -236,8 +237,9 @@ export function registerResearchCommands(program: Command): void {
         const completed = await researcher.poll(id, intervalMs);
         const completedOutputs = extractOutputs(completed);
 
-        // Generate report if output file specified
-        if (options.output && completedOutputs.length) {
+        // Generate report if output file specified (even if empty,
+        // so scripted callers always see the file they asked for).
+        if (options.output) {
           await writeReport(options.output, completedOutputs, outputContext);
         }
 

--- a/src/cli/commands/research.ts
+++ b/src/cli/commands/research.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import {
   DEEP_RESEARCH_MAX_MODEL,
   DEEP_RESEARCH_MODEL,
+  extractOutputs,
   InteractionOutput,
   McpServerConfig,
   ReportGenerator,
@@ -157,10 +158,11 @@ export function registerResearchCommands(program: Command): void {
         }
 
         const completed = await researcher.poll(interaction.id);
+        const completedOutputs = extractOutputs(completed);
 
         // Generate report if output file specified
-        if (options.output && completed.outputs) {
-          await writeReport(options.output, completed.outputs, outputContext);
+        if (options.output && completedOutputs.length) {
+          await writeReport(options.output, completedOutputs, outputContext);
         }
 
         output(outputContext, completed, () => {
@@ -168,8 +170,8 @@ export function registerResearchCommands(program: Command): void {
             `Research complete: ${completed.id}`,
             `Status: ${completed.status}`,
           ];
-          if (completed.outputs?.length) {
-            lines.push(`Outputs: ${completed.outputs.length} items`);
+          if (completedOutputs.length) {
+            lines.push(`Outputs: ${completedOutputs.length} items`);
           }
           return lines.join('\n');
         });
@@ -188,13 +190,14 @@ export function registerResearchCommands(program: Command): void {
 
       try {
         const interaction = await researcher.getStatus(id);
+        const outputs = extractOutputs(interaction);
         output(outputContext, interaction, () => {
           const lines = [
             `ID: ${interaction.id}`,
             `Status: ${interaction.status}`,
           ];
-          if (interaction.outputs?.length) {
-            lines.push(`Outputs: ${interaction.outputs.length} items`);
+          if (outputs.length) {
+            lines.push(`Outputs: ${outputs.length} items`);
           }
           return lines.join('\n');
         });
@@ -231,10 +234,11 @@ export function registerResearchCommands(program: Command): void {
         }
 
         const completed = await researcher.poll(id, intervalMs);
+        const completedOutputs = extractOutputs(completed);
 
         // Generate report if output file specified
-        if (options.output && completed.outputs) {
-          await writeReport(options.output, completed.outputs, outputContext);
+        if (options.output && completedOutputs.length) {
+          await writeReport(options.output, completedOutputs, outputContext);
         }
 
         output(outputContext, completed, () => {
@@ -242,8 +246,8 @@ export function registerResearchCommands(program: Command): void {
             `Research complete: ${completed.id}`,
             `Status: ${completed.status}`,
           ];
-          if (completed.outputs?.length) {
-            lines.push(`Outputs: ${completed.outputs.length} items`);
+          if (completedOutputs.length) {
+            lines.push(`Outputs: ${completedOutputs.length} items`);
           }
           return lines.join('\n');
         });

--- a/src/file-search/FileSearchManager.ts
+++ b/src/file-search/FileSearchManager.ts
@@ -70,19 +70,8 @@ export class FileSearchManager {
    * @returns The interaction response containing query results
    */
   async queryStore(storeName: string, query: string, model: string = 'gemini-2.5-flash'): Promise<Interaction> {
-    // The interactions API is not yet in the SDK types, so we use a type assertion
-    const client = this.client as GoogleGenAI & {
-      interactions: {
-        create(params: {
-          model: string;
-          input: string;
-          tools: Array<{ type: string; file_search_store_names: string[] }>;
-        }): Promise<Interaction>;
-      };
-    };
-
-    return await client.interactions.create({
-      model: model,
+    return await this.client.interactions.create({
+      model,
       input: query,
       tools: [
         {

--- a/src/research/ResearchManager.test.ts
+++ b/src/research/ResearchManager.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { ResearchManager, buildResearchTools } from './ResearchManager.js';
+import { ResearchManager, buildResearchTools, extractOutputs } from './ResearchManager.js';
 import { DEEP_RESEARCH_MAX_MODEL, DEEP_RESEARCH_MODEL } from './types.js';
 
 // Mock the GoogleGenAI client
@@ -242,14 +242,19 @@ describe('ResearchManager', () => {
         .mockResolvedValueOnce({
           id: 'interaction-123',
           status: 'completed',
-          outputs: [{ type: 'text', text: 'Result' }],
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'text', text: 'Result' }],
+            },
+          ],
         });
 
       const result = await manager.poll('interaction-123', 10); // 10ms interval for test
 
       expect(mockClient.interactions.get).toHaveBeenCalledTimes(2);
       expect(result.status).toBe('completed');
-      expect(result.outputs).toEqual([{ type: 'text', text: 'Result' }]);
+      expect(extractOutputs(result)).toEqual([{ type: 'text', text: 'Result' }]);
     });
 
     it('should poll research status until failure', async () => {

--- a/src/research/ResearchManager.ts
+++ b/src/research/ResearchManager.ts
@@ -6,6 +6,7 @@ import { GoogleGenAI, Interactions } from '@google/genai';
 import {
   DEEP_RESEARCH_MODEL,
   Interaction,
+  InteractionOutput,
   InteractionStatus,
   McpServerConfig,
   StartResearchParams,
@@ -17,6 +18,19 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_INITIAL_DELAY_MS = 1000;
 
 type ResearchTool = Interactions.Tool;
+type ModelOutputStep = Interactions.ModelOutputStep;
+
+/**
+ * Extracts the model's output content (text, images, etc.) from an interaction.
+ * In SDK v2, output content lives inside `model_output` steps rather than a
+ * top-level `outputs` array. This helper flattens those steps back into the
+ * v1-equivalent `InteractionOutput[]` shape that downstream code consumes.
+ */
+export function extractOutputs(interaction: Interaction): InteractionOutput[] {
+  return (interaction.steps ?? [])
+    .filter((step): step is ModelOutputStep => step.type === 'model_output')
+    .flatMap((step) => step.content ?? []);
+}
 
 /**
  * Builds the tools array sent to the Interactions API from research params.

--- a/src/research/types.ts
+++ b/src/research/types.ts
@@ -3,6 +3,7 @@
  * Re-exports SDK types and defines custom interfaces for deep research operations.
  */
 
+import type { Interactions } from '@google/genai';
 // Import Interaction type from file-search module (canonical source)
 import { Interaction, TextContent } from '../file-search/FileSearchManager.js';
 
@@ -10,13 +11,15 @@ import { Interaction, TextContent } from '../file-search/FileSearchManager.js';
 export type { Interaction, TextContent };
 
 // Additional research-specific types
-export type InteractionStatus = 'in_progress' | 'requires_action' | 'completed' | 'failed' | 'cancelled';
-export type InteractionOutput = NonNullable<Interaction['outputs']>[number];
+export type InteractionStatus = 'in_progress' | 'requires_action' | 'completed' | 'failed' | 'cancelled' | 'incomplete';
+// In SDK v2 the model output is delivered via `Interaction.steps[]` rather than `Interaction.outputs[]`;
+// the content union (text/image/audio/document/video) is exposed as `Interactions.Content`.
+export type InteractionOutput = Interactions.Content;
 
 /**
  * Terminal statuses that indicate a research interaction has finished.
  */
-export const TERMINAL_STATUSES: ReadonlyArray<InteractionStatus> = ['completed', 'failed', 'cancelled'];
+export const TERMINAL_STATUSES: ReadonlyArray<InteractionStatus> = ['completed', 'failed', 'cancelled', 'incomplete'];
 
 /**
  * Checks if a status indicates the interaction has finished.


### PR DESCRIPTION
## Summary
- Upgrade `@google/genai` from 1.x to `^2.1.0`; bump peer dep to `>=2.0.0` and library version to 0.7.0.
- Replace removed `Interaction.outputs` with a new `extractOutputs(interaction)` helper that flattens `Interaction.steps[]` → `ModelOutputStep.content[]`. All CLI read sites (`research start --wait`, `research status`, `research poll`, `query`) and re-exported types route through it.
- Add `'incomplete'` to `InteractionStatus` and `TERMINAL_STATUSES` (introduced by SDK v2).
- Drop the now-obsolete `interactions.create` type-assertion workaround in `FileSearchManager.queryStore` — v2 types this surface natively.
- Sync `TranscriptionManager`'s hand-rolled `InteractionResponse` interface to `Interactions.Interaction` from the SDK.

`models.generateContent`, `files.*`, and `fileSearchStores.*` surfaces are unaffected by v2; only Interactions changed.

**BREAKING CHANGE**: requires `@google/genai >= 2.0.0`. Library consumers reading `InteractionOutput[]` from a research interaction should now call `extractOutputs(interaction)` rather than `interaction.outputs`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 230/230 pass across 12 suites
- [x] `npm run build` succeeds; `node dist/cli/main.js --help` loads
- [x] Live smoke tests against the real Gemini API (via Doppler-injected `GEMINI_API_KEY`):
  - [x] `gemini-utils query <store> "..."` — returns text + citations (exercises `interactions.create` + `extractOutputs`)
  - [x] `gemini-utils research start "..." --google-search` — returns id + `in_progress`
  - [x] `gemini-utils research status <id>` — reads new `steps[]` shape without crashing
  - [x] `gemini-utils research delete <id>` — cleans up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Bumped requirement to genai SDK v2; `Interaction.outputs` removed — read outputs from `Interaction.steps[]` instead

* **New Features**
  * Added extractOutputs() helper to produce v1-equivalent output items
  * Added `'incomplete'` as a new interaction status value

* **Bug Fixes**
  * Removed an obsolete type-assertion workaround in file-search interactions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/gemini-utils/pull/42)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->