### PR TITLE
Migrate audio transcription to the Interactions API

### DIFF
--- a/src/audio-transcription/TranscriptionManager.test.ts
+++ b/src/audio-transcription/TranscriptionManager.test.ts
@@ -1,5 +1,20 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterAll } from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { TranscriptionManager } from './TranscriptionManager.js';
+
+/** Builds a completed interaction whose model_output contains the given text. */
+const interactionWithText = (text: string) => ({
+  id: 'interaction-123',
+  status: 'completed',
+  steps: [
+    {
+      type: 'model_output',
+      content: [{ type: 'text', text }],
+    },
+  ],
+});
 
 // Mock the GoogleGenAI client
 const createMockClient = () => ({
@@ -23,6 +38,103 @@ describe('TranscriptionManager', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     manager = new TranscriptionManager(mockClient as any);
     jest.clearAllMocks();
+  });
+
+  describe('transcribe', () => {
+    // A small local audio file used to exercise the inline-data path.
+    const tmpAudioPath = path.join(os.tmpdir(), 'gemini-utils-transcribe-test.mp3');
+
+    beforeEach(() => {
+      fs.writeFileSync(tmpAudioPath, Buffer.from('fake-mp3-bytes'));
+    });
+
+    afterAll(() => {
+      if (fs.existsSync(tmpAudioPath)) fs.unlinkSync(tmpAudioPath);
+    });
+
+    it('transcribes a remote URI via the Interactions API', async () => {
+      mockClient.interactions.create.mockResolvedValue(interactionWithText('Hello world'));
+
+      const result = await manager.transcribe({
+        audioSource: 'https://example.com/audio.mp3',
+        model: 'gemini-3-flash-preview',
+      });
+
+      expect(result.text).toBe('Hello world');
+      expect(result.model).toBe('gemini-3-flash-preview');
+      expect(mockClient.interactions.create).toHaveBeenCalledTimes(1);
+
+      const params = mockClient.interactions.create.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.model).toBe('gemini-3-flash-preview');
+      const input = params.input as Array<Record<string, unknown>>;
+      expect(input[0]).toEqual({
+        type: 'audio',
+        uri: 'https://example.com/audio.mp3',
+        mime_type: 'audio/mpeg',
+      });
+      expect(input[1]).toMatchObject({ type: 'text' });
+      expect(typeof input[1].text).toBe('string');
+    });
+
+    it('transcribes a small local file using inline base64 data', async () => {
+      mockClient.interactions.create.mockResolvedValue(interactionWithText('Local transcript'));
+
+      const result = await manager.transcribe({ audioSource: tmpAudioPath });
+
+      expect(result.text).toBe('Local transcript');
+
+      const params = mockClient.interactions.create.mock.calls[0][0] as Record<string, unknown>;
+      const input = params.input as Array<Record<string, unknown>>;
+      const expectedData = Buffer.from('fake-mp3-bytes').toString('base64');
+      expect(input[0]).toEqual({
+        type: 'audio',
+        data: expectedData,
+        mime_type: 'audio/mpeg',
+      });
+      // Inline path must not upload via the File API.
+      expect(mockClient.files.upload).not.toHaveBeenCalled();
+      expect(result.metadata?.uploadedViaFileApi).toBe(false);
+    });
+
+    it('maps audio/mp4 (.m4a) to the Interactions audio/m4a MIME type', async () => {
+      mockClient.interactions.create.mockResolvedValue(interactionWithText('m4a transcript'));
+
+      await manager.transcribe({ audioSource: 'https://example.com/audio.m4a' });
+
+      const params = mockClient.interactions.create.mock.calls[0][0] as Record<string, unknown>;
+      const input = params.input as Array<Record<string, unknown>>;
+      expect(input[0].mime_type).toBe('audio/m4a');
+    });
+
+    it('parses JSON timestamped output from the interaction', async () => {
+      const json = JSON.stringify({
+        text: 'Full transcript',
+        duration: 12.5,
+        segments: [{ startTime: 0, endTime: 5, text: 'Full' }],
+      });
+      mockClient.interactions.create.mockResolvedValue(interactionWithText('```json\n' + json + '\n```'));
+
+      const result = await manager.transcribe({
+        audioSource: 'https://example.com/audio.mp3',
+        timestamps: true,
+      });
+
+      expect(result.text).toBe('Full transcript');
+      expect(result.duration).toBe(12.5);
+      expect(result.segments).toHaveLength(1);
+    });
+
+    it('throws when the interaction returns no text', async () => {
+      mockClient.interactions.create.mockResolvedValue({
+        id: 'interaction-123',
+        status: 'completed',
+        steps: [],
+      });
+
+      await expect(
+        manager.transcribe({ audioSource: 'https://example.com/audio.mp3' })
+      ).rejects.toThrow('no text in response');
+    });
   });
 
   describe('getStatus', () => {

--- a/src/audio-transcription/TranscriptionManager.ts
+++ b/src/audio-transcription/TranscriptionManager.ts
@@ -27,21 +27,36 @@ const DEFAULT_MODEL = 'gemini-3-flash-preview';
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_POLL_TIMEOUT_MS = 600000; // 10 minutes
 
+type InteractionResponse = Interactions.Interaction;
+type AudioMimeType = Interactions.AudioContent['mime_type'];
+
 /**
- * Response from generateContent API.
+ * Maps the MIME types produced by {@link AUDIO_EXTENSION_TO_MIME} onto the
+ * audio MIME types accepted by the Interactions API's `AudioContent` input.
+ * Most types pass through unchanged; `.m4a` files report `audio/mp4` which the
+ * Interactions API spells `audio/m4a`.
  */
-interface GenerateContentResponse {
-  text?: string;
-  candidates?: Array<{
-    content?: {
-      parts?: Array<{
-        text?: string;
-      }>;
-    };
-  }>;
+function toInteractionAudioMimeType(mimeType: string): AudioMimeType {
+  if (mimeType === 'audio/mp4') return 'audio/m4a';
+  // Other supported types (audio/mpeg, audio/wav, audio/flac, audio/aac,
+  // audio/ogg, ...) map directly. Anything outside the SDK union (e.g.
+  // audio/webm) is still forwarded to the API, which validates it server-side.
+  return mimeType as AudioMimeType;
 }
 
-type InteractionResponse = Interactions.Interaction;
+/**
+ * Extracts the model's text output from a completed interaction.
+ * Output content lives inside `model_output` steps; this flattens those steps
+ * and concatenates their text parts.
+ */
+function extractInteractionText(interaction: InteractionResponse): string {
+  return (interaction.steps ?? [])
+    .filter((step): step is Interactions.ModelOutputStep => step.type === 'model_output')
+    .flatMap((step) => step.content ?? [])
+    .filter((content): content is Interactions.TextContent => content.type === 'text')
+    .map((content) => content.text)
+    .join('\n');
+}
 
 /**
  * File metadata from the Gemini Files API.
@@ -183,26 +198,20 @@ export class TranscriptionManager {
       message: 'Processing audio...',
     });
 
-    // Use generateContent API for multimodal input
-    const response = await this.client.models.generateContent({
+    // Use the Interactions API with a file URI reference for the audio input.
+    const interaction = await this.client.interactions.create({
       model,
-      contents: [
+      input: [
         {
-          role: 'user',
-          parts: [
-            {
-              fileData: {
-                fileUri: fileUri,
-                mimeType: mimeType,
-              },
-            },
-            { text: prompt },
-          ],
+          type: 'audio',
+          uri: fileUri,
+          mime_type: toInteractionAudioMimeType(mimeType),
         },
+        { type: 'text', text: prompt },
       ],
-    }) as GenerateContentResponse;
+    });
 
-    return this.parseGenerateContentResponse(response, model);
+    return this.parseInteractionResponse(interaction, model);
   }
 
   /**
@@ -224,44 +233,30 @@ export class TranscriptionManager {
       message: 'Processing audio...',
     });
 
-    // Use generateContent API for multimodal input
-    const response = await this.client.models.generateContent({
+    // Use the Interactions API with inline base64 audio data.
+    const interaction = await this.client.interactions.create({
       model,
-      contents: [
+      input: [
         {
-          role: 'user',
-          parts: [
-            {
-              inlineData: {
-                data: base64Data,
-                mimeType: mimeType,
-              },
-            },
-            { text: prompt },
-          ],
+          type: 'audio',
+          data: base64Data,
+          mime_type: toInteractionAudioMimeType(mimeType),
         },
+        { type: 'text', text: prompt },
       ],
-    }) as GenerateContentResponse;
+    });
 
-    return this.parseGenerateContentResponse(response, model);
+    return this.parseInteractionResponse(interaction, model);
   }
 
   /**
-   * Parses the generateContent response.
+   * Parses the Interactions API response into a transcription result.
    */
-  private parseGenerateContentResponse(
-    response: GenerateContentResponse,
+  private parseInteractionResponse(
+    interaction: InteractionResponse,
     model: string
   ): TranscriptionResult {
-    // Extract text from response - try direct text property first, then candidates
-    let rawText = response.text || '';
-    if (!rawText && response.candidates?.[0]?.content?.parts) {
-      rawText = response.candidates[0].content.parts
-        .filter(p => p.text)
-        .map(p => p.text!)
-        .join('\n');
-    }
-    rawText = rawText.trim();
+    const rawText = extractInteractionText(interaction).trim();
 
     if (!rawText) {
       throw new Error('Transcription failed: no text in response');

--- a/src/audio-transcription/TranscriptionManager.ts
+++ b/src/audio-transcription/TranscriptionManager.ts
@@ -199,8 +199,11 @@ export class TranscriptionManager {
     });
 
     // Use the Interactions API with a file URI reference for the audio input.
+    // Run synchronously (background: false) so the response carries the
+    // model_output steps that parseInteractionResponse reads immediately.
     const interaction = await this.client.interactions.create({
       model,
+      background: false,
       input: [
         {
           type: 'audio',
@@ -234,8 +237,11 @@ export class TranscriptionManager {
     });
 
     // Use the Interactions API with inline base64 audio data.
+    // Run synchronously (background: false) so the response carries the
+    // model_output steps that parseInteractionResponse reads immediately.
     const interaction = await this.client.interactions.create({
       model,
+      background: false,
       input: [
         {
           type: 'audio',


### PR DESCRIPTION
## Summary

Completes this library's move to the GA Gemini **Interactions API**. `ResearchManager` and `FileSearchManager` query were already on `interactions.create/get/cancel/delete`; the one remaining legacy inference path was **audio transcription**, which used `models.generateContent`. This migrates it.

## Changes

`src/audio-transcription/TranscriptionManager.ts`
- Replace both `models.generateContent({ contents: [{role, parts}] })` calls (URI + inline paths) with `interactions.create({ model, input: [audioContent, textContent] })`, using the Interactions content shape (`{ type: 'audio', uri | data, mime_type }` + `{ type: 'text', text }`).
- Add `toInteractionAudioMimeType()` to bridge the SDK's constrained `AudioContent.mime_type` union — maps `.m4a` (`audio/mp4`) → `audio/m4a`; other types pass through (`audio/webm` still forwarded for server-side validation, preserving prior behavior).
- Add `extractInteractionText()` to read output from `model_output` steps (mirrors `ResearchManager.extractOutputs`); drop the old `candidates[].content.parts` parsing and the dead `GenerateContentResponse` interface.

`src/audio-transcription/TranscriptionManager.test.ts`
- `transcribe()` was previously **untested**. Added coverage: remote URI, inline base64, `audio/mp4 → audio/m4a` mapping, JSON timestamped parsing, and the empty-response error.

## Out of scope (intentionally unchanged)

`files.*` and `fileSearchStores.*` are resource/storage APIs the Interactions API *consumes* (audio via URI/inline, RAG via the `file_search` tool) — they have no interactions equivalent.

## Verification

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` clean
- ✅ `npm run build` clean
- ✅ **235 tests pass** across 12 suites (was 230 — +5 new transcription tests)
- ✅ No `generateContent` / `models.*` inference calls remain in source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio transcription reliability for both remote audio URLs and local audio uploads.
  * Enhanced error handling when transcription results can’t be extracted.
  * Added improved handling for additional audio formats, including `.m4a`.

* **Tests**
  * Expanded transcription test coverage to validate multiple input scenarios and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->