### PR TITLE
ci: route all npm publishes through release-please.yml for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,10 @@
 name: Publish to npm
 
+# Invoked only via workflow_call from release-please.yml so that workflow stays
+# the single OIDC entry point npm trusts. npm trusted publishing matches the
+# top-level (entry) workflow, not the reusable one it calls, so this file must
+# not be triggered directly.
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Release tag to publish from, e.g. v0.6.0'
-        required: true
   workflow_call:
     inputs:
       ref:
@@ -25,19 +21,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Validate manual ref is a version tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Validate ref is a version tag
         run: |
           REF="${{ inputs.ref }}"
           if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
-            echo "::error::Input ref must be a version tag (e.g. v1.2.3); got '$REF'."
+            echo "::error::ref must be a version tag (e.g. v1.2.3); got '$REF'."
             exit 1
           fi
 
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,10 @@ jobs:
 
     steps:
       - name: Validate ref is a version tag
+        env:
+          REF: ${{ inputs.ref }}
         run: |
-          REF="${{ inputs.ref }}"
-          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$ ]]; then
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::ref must be a version tag (e.g. v1.2.3); got '$REF'."
             exit 1
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Release tag to publish from, e.g. v1.1.0'
+        required: true
 
 permissions:
   contents: write
@@ -12,6 +17,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -20,12 +26,26 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
 
+  # Automated publish after release-please cuts a release. Runs publish.yml via
+  # workflow_call so this workflow stays the OIDC entry point npm trusts.
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_created == 'true' }}
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/publish.yml
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}
+
+  # Manual re-publish of an existing tag (e.g. gh workflow run release-please.yml
+  # -f ref=v1.1.0). Routed through the same entry workflow so the OIDC trusted
+  # publisher (release-please.yml) matches.
+  publish-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
   # -f ref=v1.1.0). Routed through the same entry workflow so the OIDC trusted
   # publisher (release-please.yml) matches.
   publish-manual:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Problem

npm trusted publishing matches the OIDC token against the **top-level (entry) workflow**, not the reusable workflow it `workflow_call`s. We proved this empirically while shipping v1.1.0:

| Path | Entry workflow | Trusted publisher | Result |
|------|----------------|-------------------|--------|
| Automated (release-please → `workflow_call` publish.yml) | `release-please.yml` | `publish.yml` | ❌ `ENEEDAUTH` |
| Manual (`workflow_dispatch` on publish.yml) | `publish.yml` | `publish.yml` | ✅ published |

Since npm only allows **one** trusted publisher per package, both publish paths must enter through the same workflow.

## Change

Make `release-please.yml` the single OIDC entry point for both paths:
- `release-please.yml` gains a `workflow_dispatch` (with a `ref` input) and a `publish-manual` job for manual re-publishes; automated jobs are gated on `push`.
- `publish.yml` is now **workflow_call-only** so it can never be an entry workflow (its dead `on: push: tags` trigger — which GITHUB_TOKEN never fired anyway — and direct `workflow_dispatch` are removed).

## Required manual step (npm)

Change the trusted publisher workflow on npmjs.com for `@allenhutchison/gemini-utils` from `publish.yml` → **`release-please.yml`**.

## After merge

- Automated: next release-please release publishes automatically.
- Manual re-publish: `gh workflow run release-please.yml -f ref=vX.Y.Z`

https://claude.ai/code/session_01UAS7LhTM9s51rYAzrfxcSf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to support both automatic publishing on new releases and manual republishing from a selected tag.
  * Added stricter tag validation when publishing and aligned checkout behavior with the chosen release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->