### PR TITLE
feat: browser-safe subpath exports; drop Node `path` from MIME modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,33 @@ npx @allenhutchison/gemini-utils stores list --json | jq '.[] | .name'
 
 ## Usage
 
+### Import surface & browser/mobile safety
+
+The package is marked `"sideEffects": false` and exposes granular subpath exports in
+addition to the top-level barrel:
+
+| Entry | Contents | Node built-ins |
+| --- | --- | --- |
+| `@allenhutchison/gemini-utils` | everything (barrel) | pulls in `fs`/`path`/`crypto`/`url` transitively |
+| `@allenhutchison/gemini-utils/mime` | MIME/extension helpers + maps (`getMimeTypeWithFallback`, `EXTENSION_TO_MIME`, …) | **none** |
+| `@allenhutchison/gemini-utils/support-registry` | extension/support registry + comprehensive map | **none** |
+| `@allenhutchison/gemini-utils/file-search` | file upload / search managers | `fs`, `path`, `crypto` |
+| `@allenhutchison/gemini-utils/research` | deep-research managers | (via `@google/genai`) |
+| `@allenhutchison/gemini-utils/audio-transcription` | transcription managers + audio MIME helpers | `fs`, `path`, `url` |
+
+Consumers that must stay free of Node built-ins at load time (browser or mobile bundles,
+e.g. Obsidian plugins) should import MIME/extension helpers from the built-in-free
+`/mime` or `/support-registry` subpaths rather than the barrel, and lazy-load the
+file-search / research / audio-transcription managers only when a desktop feature runs:
+
+```typescript
+// Safe anywhere — no Node built-ins are evaluated:
+import { getMimeTypeWithFallback, EXTENSION_TO_MIME } from '@allenhutchison/gemini-utils/mime';
+
+// Desktop-only; defer so the fs/path/crypto requires never run at load:
+const { FileUploader } = await import('@allenhutchison/gemini-utils/file-search');
+```
+
 ### Basic File Upload
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -5,6 +5,34 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./mime": {
+      "types": "./dist/file-search/mimeTypes.d.ts",
+      "import": "./dist/file-search/mimeTypes.js"
+    },
+    "./file-search": {
+      "types": "./dist/file-search/index.d.ts",
+      "import": "./dist/file-search/index.js"
+    },
+    "./research": {
+      "types": "./dist/research/index.d.ts",
+      "import": "./dist/research/index.js"
+    },
+    "./audio-transcription": {
+      "types": "./dist/audio-transcription/index.d.ts",
+      "import": "./dist/audio-transcription/index.js"
+    },
+    "./support-registry": {
+      "types": "./dist/support-registry/index.d.ts",
+      "import": "./dist/support-registry/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",

--- a/src/audio-transcription/audioMimeTypes.ts
+++ b/src/audio-transcription/audioMimeTypes.ts
@@ -3,7 +3,7 @@
  * Based on Gemini API supported audio formats.
  */
 
-import * as path from 'path';
+import { extname } from '../common/pathHelpers.js';
 
 /**
  * Mapping of audio file extensions to MIME types supported by Gemini.
@@ -77,7 +77,7 @@ export function isAudioExtensionSupported(extension: string): boolean {
  * @returns MIME type string, or null if extension is not supported
  */
 export function getAudioMimeType(filePath: string): string | null {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = extname(filePath).toLowerCase();
   return AUDIO_EXTENSION_TO_MIME[ext] || null;
 }
 
@@ -89,7 +89,7 @@ export function getAudioMimeType(filePath: string): string | null {
  * @throws UnsupportedAudioTypeError if the file type is not supported
  */
 export function requireAudioMimeType(filePath: string): string {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = extname(filePath).toLowerCase();
   const mimeType = AUDIO_EXTENSION_TO_MIME[ext];
   if (!mimeType) {
     throw new UnsupportedAudioTypeError(filePath, ext);

--- a/src/common/pathHelpers.test.ts
+++ b/src/common/pathHelpers.test.ts
@@ -1,0 +1,32 @@
+import { extname } from './pathHelpers.js';
+
+describe('extname', () => {
+  it('returns the extension including the leading dot', () => {
+    expect(extname('note.md')).toBe('.md');
+    expect(extname('photo.JPG')).toBe('.JPG');
+  });
+
+  it('uses only the last dot of the final segment', () => {
+    expect(extname('archive.tar.gz')).toBe('.gz');
+    expect(extname('a/b/c.d.e.txt')).toBe('.txt');
+  });
+
+  it('strips the directory portion for both separators', () => {
+    expect(extname('/usr/local/file.pdf')).toBe('.pdf');
+    expect(extname('C:\\dir\\doc.docx')).toBe('.docx');
+  });
+
+  it('returns empty string when there is no extension', () => {
+    expect(extname('README')).toBe('');
+    expect(extname('/path/to/noext')).toBe('');
+  });
+
+  it('treats leading-dot dotfiles as having no extension', () => {
+    expect(extname('.gitignore')).toBe('');
+    expect(extname('/etc/.bashrc')).toBe('');
+  });
+
+  it('handles trailing dots the way path.extname does', () => {
+    expect(extname('foo.')).toBe('.');
+  });
+});

--- a/src/common/pathHelpers.ts
+++ b/src/common/pathHelpers.ts
@@ -1,0 +1,29 @@
+/**
+ * Tiny, dependency-free path helpers.
+ *
+ * These exist so that the light-weight MIME/extension modules can run in any
+ * JavaScript environment (including browser/mobile bundles) without importing
+ * the Node.js `path` built-in. Pulling in `path` there would force the whole
+ * module graph to evaluate a Node built-in at load time — see
+ * https://github.com/allenhutchison/obsidian-gemini/issues/1154.
+ */
+
+/**
+ * Returns the extension of a path, from the last `.` in the final path segment
+ * to the end. Mirrors `path.extname` for the cases that matter to extension
+ * lookups: a leading-dot segment (e.g. `.gitignore`) and a segment with no dot
+ * both yield `''`. Handles both `/` and `\` separators.
+ *
+ * @param filePath - Path or file name to inspect
+ * @returns The extension including the leading dot (e.g. `.mp3`), or `''`
+ */
+export function extname(filePath: string): string {
+  const lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  const base = lastSlash === -1 ? filePath : filePath.slice(lastSlash + 1);
+  const dot = base.lastIndexOf('.');
+  // No dot, or a leading-dot dotfile (e.g. `.gitignore`) → no extension.
+  if (dot <= 0) {
+    return '';
+  }
+  return base.slice(dot);
+}

--- a/src/file-search/mimeTypes.ts
+++ b/src/file-search/mimeTypes.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { extname } from '../common/pathHelpers.js';
 
 /**
  * Validated mapping of file extensions to MIME types supported by Gemini File Search API.
@@ -248,7 +248,7 @@ export function isExtensionSupported(extension: string): boolean {
  * @returns MIME type string, or null if extension is not supported
  */
 export function getMimeType(filePath: string): string | null {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = extname(filePath).toLowerCase();
   return EXTENSION_TO_MIME[ext] || null;
 }
 
@@ -261,7 +261,7 @@ export function getMimeType(filePath: string): string | null {
  * @returns Object with mimeType and whether fallback was used, or null if unsupported
  */
 export function getMimeTypeWithFallback(filePath: string): { mimeType: string; isFallback: boolean } | null {
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = extname(filePath).toLowerCase();
 
   // First try validated MIME types
   const validatedMime = EXTENSION_TO_MIME[ext];


### PR DESCRIPTION
## Motivation

The package ships a single barrel (`src/index.ts` = `export *` of file-search, research, audio-transcription, support-registry) with **no `exports` map and no `sideEffects` flag**. As a result, importing *any* value from `@allenhutchison/gemini-utils` evaluates the entire module graph — dragging in the `fs`/`path`/`crypto`/`url` Node built-ins at load time.

Browser/mobile consumers can't touch Node built-ins at load. In the Obsidian plugin this surfaces as a cascade of warning toasts on every plugin (re)load (allenhutchison/obsidian-gemini#1154). The fix is to make the light MIME/extension modules built-in-free and let consumers import them (and only them) without pulling in the heavy desktop modules.

## Changes

- **De-`path` the light MIME modules.** New dependency-free `common/pathHelpers.ts` (`extname`) replaces `path.extname` in `mimeTypes.ts` and `audioMimeTypes.ts`. Those modules — which back the plugin's hot classification path (`EXTENSION_TO_MIME`, `TEXT_FALLBACK_EXTENSIONS`, `getMimeTypeWithFallback`, `isExtensionSupportedWithFallback`) — are now completely built-in-free.
- **`"sideEffects": false`** — all modules are pure exports, so bundlers can tree-shake the heavy fs/crypto modules out of a consumer's load path.
- **`exports` map with granular subpaths:**
  | Entry | Node built-ins |
  | --- | --- |
  | `.` (barrel, unchanged) | transitive fs/path/crypto/url |
  | `./mime`, `./support-registry` | **none** |
  | `./file-search`, `./research`, `./audio-transcription` | as before |

  Each entry carries `types`/`import` conditions for NodeNext resolution.
- **Docs**: README "Import surface & browser/mobile safety" section with guidance to import MIME helpers from `/mime` and lazy-load the desktop managers.
- **Test**: `pathHelpers.test.ts` locks in `extname` semantics (multi-dot, dotfiles, both separators, no-ext).

## Verification

- ✅ `npm test` — **241/241 pass** (was 235 + 6 new); `npm run lint` clean; `npm run build` clean
- ✅ De-path'd helpers behave identically (uppercase, multi-dot, dotfiles, Windows separators)
- ✅ Static import-closure walk confirms **zero Node built-ins** transitively reachable from `./mime`, `./support-registry`, and the audio-MIME entry
- ✅ Every `exports` target file exists in `dist/`

## Compatibility / semver note

Existing barrel imports (`import { FileUploader } from '@allenhutchison/gemini-utils'`) are unchanged — `.` still maps to the barrel. The `exports` map does make the package's subpaths an allowlist, so any consumer deep-importing `@allenhutchison/gemini-utils/dist/...` would now be blocked; the only known consumer (the Obsidian plugin) uses the bare specifier, so this is safe in practice. Landing as `feat` (minor).

## Follow-up

Unblocks allenhutchison/obsidian-gemini#1154: bump this dep in the plugin, point `file-classification.ts` / `obsidian-file-adapter.ts` at `/mime`, keep the desktop managers behind lazy `await import()`.

https://claude.ai/code/session_01ATYuqvrvDTbASN7TD2QHW1